### PR TITLE
symboltable: TraverseOrder renamed to TraversalOrder

### DIFF
--- a/symboltable/avl.go
+++ b/symboltable/avl.go
@@ -496,7 +496,7 @@ func (t *avl) Range(lo, hi interface{}) []KeyValue {
 	return kvs[0:len]
 }
 
-func (t *avl) _traverse(n *avlNode, order TraverseOrder, visit func(*avlNode) bool) bool {
+func (t *avl) _traverse(n *avlNode, order TraversalOrder, visit func(*avlNode) bool) bool {
 	if n == nil {
 		return true
 	}
@@ -520,7 +520,7 @@ func (t *avl) _traverse(n *avlNode, order TraverseOrder, visit func(*avlNode) bo
 }
 
 // Traverse is used for visiting all key-value pairs in AVL tree.
-func (t *avl) Traverse(order TraverseOrder, visit VisitFunc) {
+func (t *avl) Traverse(order TraversalOrder, visit VisitFunc) {
 	if order != PreOrder && order != InOrder && order != PostOrder {
 		return
 	}

--- a/symboltable/bst.go
+++ b/symboltable/bst.go
@@ -432,7 +432,7 @@ func (t *bst) Range(lo, hi interface{}) []KeyValue {
 	return kvs[0:len]
 }
 
-func (t *bst) _traverse(n *bstNode, order TraverseOrder, visit func(*bstNode) bool) bool {
+func (t *bst) _traverse(n *bstNode, order TraversalOrder, visit func(*bstNode) bool) bool {
 	if n == nil {
 		return true
 	}
@@ -456,7 +456,7 @@ func (t *bst) _traverse(n *bstNode, order TraverseOrder, visit func(*bstNode) bo
 }
 
 // Traverse is used for visiting all key-value pairs in BST.
-func (t *bst) Traverse(order TraverseOrder, visit VisitFunc) {
+func (t *bst) Traverse(order TraversalOrder, visit VisitFunc) {
 	if order != PreOrder && order != InOrder && order != PostOrder {
 		return
 	}

--- a/symboltable/red_black.go
+++ b/symboltable/red_black.go
@@ -622,7 +622,7 @@ func (t *redBlack) Range(lo, hi interface{}) []KeyValue {
 	return kvs[0:len]
 }
 
-func (t *redBlack) _traverse(n *rbNode, order TraverseOrder, visit func(*rbNode) bool) bool {
+func (t *redBlack) _traverse(n *rbNode, order TraversalOrder, visit func(*rbNode) bool) bool {
 	if n == nil {
 		return true
 	}
@@ -646,7 +646,7 @@ func (t *redBlack) _traverse(n *rbNode, order TraverseOrder, visit func(*rbNode)
 }
 
 // Traverse is used for visiting all key-value pairs in Red-Black tree.
-func (t *redBlack) Traverse(order TraverseOrder, visit VisitFunc) {
+func (t *redBlack) Traverse(order TraversalOrder, visit VisitFunc) {
 	if order != PreOrder && order != InOrder && order != PostOrder {
 		return
 	}

--- a/symboltable/symboltable.go
+++ b/symboltable/symboltable.go
@@ -4,12 +4,12 @@
 // Symbol tables can be ordered or unordered.
 package symboltable
 
-// TraverseOrder specifies the order for traversing nodes of a tree.
-type TraverseOrder int
+// TraversalOrder is the order for traversing nodes in a tree.
+type TraversalOrder int
 
 const (
 	// PreOrder is pre-order traversal.
-	PreOrder = iota
+	PreOrder TraversalOrder = iota
 	// InOrder is in-order traversal.
 	InOrder
 	// PostOrder is post-order traversal.
@@ -54,7 +54,7 @@ type (
 		DeleteMax() (interface{}, interface{})
 		RangeSize(interface{}, interface{}) int
 		Range(interface{}, interface{}) []KeyValue
-		Traverse(TraverseOrder, VisitFunc)
+		Traverse(TraversalOrder, VisitFunc)
 		Graphviz() string
 	}
 )


### PR DESCRIPTION
## Description

  - [x] Rename `TraverseOrder` to `TraversalOrder`
  - [x] Set the `TraversalOrder` type for constants

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
