### PR TITLE
Add Equals to SymbolTable and Trie APIs

### DIFF
--- a/automata/automata.go
+++ b/automata/automata.go
@@ -1,6 +1,11 @@
 // Package automata provides data structures and algorithms for working with finite automata, a.k.a. finite state machines.
 package automata
 
+import (
+	"github.com/moorara/algo/generic"
+	"github.com/moorara/algo/symboltable"
+)
+
 // State represents a state in a finite automaton.
 type State int
 
@@ -66,3 +71,21 @@ func ToString(s string) String {
 
 	return res
 }
+
+var (
+	cmpState  = generic.NewCompareFunc[State]()
+	cmpSymbol = generic.NewCompareFunc[Symbol]()
+
+	eqState  = generic.NewEqualFunc[State]()
+	eqStates = func(a, b States) bool {
+		return a.Equals(b)
+	}
+
+	eqSymbolState = func(a, b symboltable.OrderedSymbolTable[Symbol, State]) bool {
+		return a.Equals(b)
+	}
+
+	eqSymbolStates = func(a, b symboltable.OrderedSymbolTable[Symbol, States]) bool {
+		return a.Equals(b)
+	}
+)

--- a/automata/dfa.go
+++ b/automata/dfa.go
@@ -3,7 +3,6 @@ package automata
 import (
 	"fmt"
 
-	"github.com/moorara/algo/generic"
 	"github.com/moorara/algo/internal/graphviz"
 	"github.com/moorara/algo/symboltable"
 )
@@ -18,12 +17,10 @@ type DFA struct {
 // NewDFA creates a new deterministic finite automaton.
 // Finite automata are recognizers; they simply say yes or no for each possible input string.
 func NewDFA(start State, final States) *DFA {
-	cmpKey := generic.NewCompareFunc[State]()
-
 	return &DFA{
 		Start: start,
 		Final: final,
-		trans: symboltable.NewRedBlack[State, symboltable.OrderedSymbolTable[Symbol, State]](cmpKey),
+		trans: symboltable.NewRedBlack[State, symboltable.OrderedSymbolTable[Symbol, State]](cmpState, eqSymbolState),
 	}
 }
 
@@ -32,8 +29,7 @@ func (d *DFA) Add(s State, a Symbol, next State) {
 	if v, ok := d.trans.Get(s); ok {
 		v.Put(a, next)
 	} else {
-		cmpKey := generic.NewCompareFunc[Symbol]()
-		v = symboltable.NewRedBlack[Symbol, State](cmpKey)
+		v = symboltable.NewRedBlack[Symbol, State](cmpSymbol, eqState)
 		v.Put(a, next)
 		d.trans.Put(s, v)
 	}

--- a/automata/nfa.go
+++ b/automata/nfa.go
@@ -3,7 +3,6 @@ package automata
 import (
 	"fmt"
 
-	"github.com/moorara/algo/generic"
 	"github.com/moorara/algo/internal/graphviz"
 	"github.com/moorara/algo/list"
 	"github.com/moorara/algo/symboltable"
@@ -19,12 +18,10 @@ type NFA struct {
 // NewNFA creates a new non-deterministic finite automaton.
 // Finite automata are recognizers; they simply say yes or no for each possible input string.
 func NewNFA(start State, final States) *NFA {
-	cmpKey := generic.NewCompareFunc[State]()
-
 	return &NFA{
 		Start: start,
 		Final: final,
-		trans: symboltable.NewRedBlack[State, symboltable.OrderedSymbolTable[Symbol, States]](cmpKey),
+		trans: symboltable.NewRedBlack[State, symboltable.OrderedSymbolTable[Symbol, States]](cmpState, eqSymbolStates),
 	}
 }
 
@@ -67,8 +64,7 @@ func (n *NFA) Add(s State, a Symbol, next States) {
 	if v, ok := n.trans.Get(s); ok {
 		v.Put(a, next)
 	} else {
-		cmpKey := generic.NewCompareFunc[Symbol]()
-		v = symboltable.NewRedBlack[Symbol, States](cmpKey)
+		v = symboltable.NewRedBlack[Symbol, States](cmpSymbol, eqStates)
 		v.Put(a, next)
 		n.trans.Put(s, v)
 	}

--- a/symboltable/avl_test.go
+++ b/symboltable/avl_test.go
@@ -1,6 +1,10 @@
 package symboltable
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moorara/algo/generic"
+)
 
 func getAVLTests() []orderedSymbolTableTest[string, int] {
 	tests := getOrderedSymbolTableTests()
@@ -15,6 +19,8 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 	tests[0].expectedRLVTraverse = []KeyValue[string, int]{{"C", 3}, {"A", 1}, {"B", 2}}
 	tests[0].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}}
 	tests[0].expectedDescendingTraverse = []KeyValue[string, int]{{"C", 3}, {"B", 2}, {"A", 1}}
+	tests[0].equals = nil
+	tests[0].expectedEquals = false
 	tests[0].expectedGraphviz = `strict digraph "AVL" {
   concentrate=false;
   node [shape=oval];
@@ -37,6 +43,8 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 	tests[1].expectedRLVTraverse = []KeyValue[string, int]{{"E", 5}, {"C", 3}, {"D", 4}, {"A", 1}, {"B", 2}}
 	tests[1].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
 	tests[1].expectedDescendingTraverse = []KeyValue[string, int]{{"E", 5}, {"D", 4}, {"C", 3}, {"B", 2}, {"A", 1}}
+	tests[1].equals = NewAVL[string, int](generic.NewCompareFunc[string](), nil)
+	tests[1].expectedEquals = false
 	tests[1].expectedGraphviz = `strict digraph "AVL" {
   concentrate=false;
   node [shape=oval];
@@ -63,6 +71,11 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 	tests[2].expectedRLVTraverse = []KeyValue[string, int]{{"S", 19}, {"M", 13}, {"P", 16}, {"G", 7}, {"A", 1}, {"D", 4}, {"J", 10}}
 	tests[2].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
 	tests[2].expectedDescendingTraverse = []KeyValue[string, int]{{"S", 19}, {"P", 16}, {"M", 13}, {"J", 10}, {"G", 7}, {"D", 4}, {"A", 1}}
+	tests[2].equals = NewAVL[string, int](generic.NewCompareFunc[string](), nil)
+	tests[2].equals.Put("D", 4)
+	tests[2].equals.Put("J", 10)
+	tests[2].equals.Put("P", 16)
+	tests[2].expectedEquals = false
 	tests[2].expectedGraphviz = `strict digraph "AVL" {
   concentrate=false;
   node [shape=oval];
@@ -93,6 +106,15 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 	tests[3].expectedRLVTraverse = []KeyValue[string, int]{{"dome", 7}, {"dad", 3}, {"dance", 13}, {"band", 11}, {"baby", 5}, {"balloon", 17}, {"box", 2}}
 	tests[3].expectedAscendingTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
 	tests[3].expectedDescendingTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
+	tests[3].equals = NewAVL[string, int](generic.NewCompareFunc[string](), nil)
+	tests[3].equals.Put("box", 2)
+	tests[3].equals.Put("dad", 3)
+	tests[3].equals.Put("baby", 5)
+	tests[3].equals.Put("dome", 7)
+	tests[3].equals.Put("band", 11)
+	tests[3].equals.Put("dance", 13)
+	tests[3].equals.Put("balloon", 17)
+	tests[3].expectedEquals = true
 	tests[3].expectedGraphviz = `strict digraph "AVL" {
   concentrate=false;
   node [shape=oval];
@@ -120,7 +142,7 @@ func TestAVL(t *testing.T) {
 	tests := getAVLTests()
 
 	for _, tc := range tests {
-		avl := NewAVL[string, int](tc.cmpKey)
+		avl := NewAVL[string, int](tc.cmpKey, tc.eqVal)
 		runOrderedSymbolTableTest(t, avl, tc)
 	}
 }

--- a/symboltable/benchmark_test.go
+++ b/symboltable/benchmark_test.go
@@ -89,19 +89,20 @@ func BenchmarkOrderedSymbolTable_Put(b *testing.B) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	cmpKey := generic.NewCompareFunc[string]()
+	eqVal := generic.NewEqualFunc[int]()
 
 	b.Run("BST.Put", func(b *testing.B) {
-		ost := NewBST[string, int](cmpKey)
+		ost := NewBST[string, int](cmpKey, eqVal)
 		runPutBenchmark(b, ost)
 	})
 
 	b.Run("AVL.Put", func(b *testing.B) {
-		ost := NewAVL[string, int](cmpKey)
+		ost := NewAVL[string, int](cmpKey, eqVal)
 		runPutBenchmark(b, ost)
 	})
 
 	b.Run("RedBlack.Put", func(b *testing.B) {
-		ost := NewRedBlack[string, int](cmpKey)
+		ost := NewRedBlack[string, int](cmpKey, eqVal)
 		runPutBenchmark(b, ost)
 	})
 }
@@ -110,19 +111,20 @@ func BenchmarkOrderedSymbolTable_Get(b *testing.B) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	cmpKey := generic.NewCompareFunc[string]()
+	eqVal := generic.NewEqualFunc[int]()
 
 	b.Run("BST.Get", func(b *testing.B) {
-		ost := NewBST[string, int](cmpKey)
+		ost := NewBST[string, int](cmpKey, eqVal)
 		runGetBenchmark(b, ost)
 	})
 
 	b.Run("AVL.Get", func(b *testing.B) {
-		ost := NewAVL[string, int](cmpKey)
+		ost := NewAVL[string, int](cmpKey, eqVal)
 		runGetBenchmark(b, ost)
 	})
 
 	b.Run("RedBlack.Get", func(b *testing.B) {
-		ost := NewRedBlack[string, int](cmpKey)
+		ost := NewRedBlack[string, int](cmpKey, eqVal)
 		runGetBenchmark(b, ost)
 	})
 }
@@ -131,19 +133,20 @@ func BenchmarkOrderedSymbolTable_Delete(b *testing.B) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	cmpKey := generic.NewCompareFunc[string]()
+	eqVal := generic.NewEqualFunc[int]()
 
 	b.Run("BST.Delete", func(b *testing.B) {
-		ost := NewBST[string, int](cmpKey)
+		ost := NewBST[string, int](cmpKey, eqVal)
 		runDeleteBenchmark(b, ost)
 	})
 
 	b.Run("AVL.Delete", func(b *testing.B) {
-		ost := NewAVL[string, int](cmpKey)
+		ost := NewAVL[string, int](cmpKey, eqVal)
 		runDeleteBenchmark(b, ost)
 	})
 
 	b.Run("RedBlack.Delete", func(b *testing.B) {
-		ost := NewRedBlack[string, int](cmpKey)
+		ost := NewRedBlack[string, int](cmpKey, eqVal)
 		runDeleteBenchmark(b, ost)
 	})
 }

--- a/symboltable/bst_test.go
+++ b/symboltable/bst_test.go
@@ -1,6 +1,10 @@
 package symboltable
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moorara/algo/generic"
+)
 
 func getBSTTests() []orderedSymbolTableTest[string, int] {
 	tests := getOrderedSymbolTableTests()
@@ -15,6 +19,8 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 	tests[0].expectedRLVTraverse = []KeyValue[string, int]{{"C", 3}, {"A", 1}, {"B", 2}}
 	tests[0].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}}
 	tests[0].expectedDescendingTraverse = []KeyValue[string, int]{{"C", 3}, {"B", 2}, {"A", 1}}
+	tests[0].equals = nil
+	tests[0].expectedEquals = false
 	tests[0].expectedGraphviz = `strict digraph "BST" {
   concentrate=false;
   node [shape=oval];
@@ -37,6 +43,8 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 	tests[1].expectedRLVTraverse = []KeyValue[string, int]{{"E", 5}, {"D", 4}, {"C", 3}, {"A", 1}, {"B", 2}}
 	tests[1].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
 	tests[1].expectedDescendingTraverse = []KeyValue[string, int]{{"E", 5}, {"D", 4}, {"C", 3}, {"B", 2}, {"A", 1}}
+	tests[1].equals = NewBST[string, int](generic.NewCompareFunc[string](), nil)
+	tests[1].expectedEquals = false
 	tests[1].expectedGraphviz = `strict digraph "BST" {
   concentrate=false;
   node [shape=oval];
@@ -63,6 +71,11 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 	tests[2].expectedRLVTraverse = []KeyValue[string, int]{{"S", 19}, {"M", 13}, {"P", 16}, {"G", 7}, {"A", 1}, {"D", 4}, {"J", 10}}
 	tests[2].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
 	tests[2].expectedDescendingTraverse = []KeyValue[string, int]{{"S", 19}, {"P", 16}, {"M", 13}, {"J", 10}, {"G", 7}, {"D", 4}, {"A", 1}}
+	tests[2].equals = NewBST[string, int](generic.NewCompareFunc[string](), nil)
+	tests[2].equals.Put("J", 10)
+	tests[2].equals.Put("D", 4)
+	tests[2].equals.Put("P", 16)
+	tests[2].expectedEquals = false
 	tests[2].expectedGraphviz = `strict digraph "BST" {
   concentrate=false;
   node [shape=oval];
@@ -93,6 +106,15 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 	tests[3].expectedRLVTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}}
 	tests[3].expectedAscendingTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
 	tests[3].expectedDescendingTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
+	tests[3].equals = NewBST[string, int](generic.NewCompareFunc[string](), nil)
+	tests[3].equals.Put("box", 2)
+	tests[3].equals.Put("band", 11)
+	tests[3].equals.Put("balloon", 17)
+	tests[3].equals.Put("baby", 5)
+	tests[3].equals.Put("dad", 3)
+	tests[3].equals.Put("dance", 13)
+	tests[3].equals.Put("dome", 7)
+	tests[3].expectedEquals = true
 	tests[3].expectedGraphviz = `strict digraph "BST" {
   concentrate=false;
   node [shape=oval];
@@ -120,7 +142,7 @@ func TestBST(t *testing.T) {
 	tests := getBSTTests()
 
 	for _, tc := range tests {
-		bst := NewBST[string, int](tc.cmpKey)
+		bst := NewBST[string, int](tc.cmpKey, tc.eqVal)
 		runOrderedSymbolTableTest(t, bst, tc)
 	}
 }

--- a/symboltable/red_black_test.go
+++ b/symboltable/red_black_test.go
@@ -1,6 +1,10 @@
 package symboltable
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moorara/algo/generic"
+)
 
 func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 	tests := getOrderedSymbolTableTests()
@@ -15,6 +19,8 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 	tests[0].expectedRLVTraverse = []KeyValue[string, int]{{"C", 3}, {"A", 1}, {"B", 2}}
 	tests[0].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}}
 	tests[0].expectedDescendingTraverse = []KeyValue[string, int]{{"C", 3}, {"B", 2}, {"A", 1}}
+	tests[0].equals = nil
+	tests[0].expectedEquals = false
 	tests[0].expectedGraphviz = `strict digraph "Red-Black" {
   concentrate=false;
   node [style=filled, shape=oval];
@@ -37,6 +43,8 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 	tests[1].expectedRLVTraverse = []KeyValue[string, int]{{"E", 5}, {"C", 3}, {"A", 1}, {"B", 2}, {"D", 4}}
 	tests[1].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
 	tests[1].expectedDescendingTraverse = []KeyValue[string, int]{{"E", 5}, {"D", 4}, {"C", 3}, {"B", 2}, {"A", 1}}
+	tests[1].equals = NewRedBlack[string, int](generic.NewCompareFunc[string](), nil)
+	tests[1].expectedEquals = false
 	tests[1].expectedGraphviz = `strict digraph "Red-Black" {
   concentrate=false;
   node [style=filled, shape=oval];
@@ -63,6 +71,11 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 	tests[2].expectedRLVTraverse = []KeyValue[string, int]{{"S", 19}, {"M", 13}, {"P", 16}, {"G", 7}, {"A", 1}, {"D", 4}, {"J", 10}}
 	tests[2].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
 	tests[2].expectedDescendingTraverse = []KeyValue[string, int]{{"S", 19}, {"P", 16}, {"M", 13}, {"J", 10}, {"G", 7}, {"D", 4}, {"A", 1}}
+	tests[2].equals = NewRedBlack[string, int](generic.NewCompareFunc[string](), nil)
+	tests[2].equals.Put("D", 4)
+	tests[2].equals.Put("J", 10)
+	tests[2].equals.Put("P", 16)
+	tests[2].expectedEquals = false
 	tests[2].expectedGraphviz = `strict digraph "Red-Black" {
   concentrate=false;
   node [style=filled, shape=oval];
@@ -93,6 +106,15 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 	tests[3].expectedRLVTraverse = []KeyValue[string, int]{{"dome", 7}, {"dad", 3}, {"dance", 13}, {"band", 11}, {"baby", 5}, {"balloon", 17}, {"box", 2}}
 	tests[3].expectedAscendingTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
 	tests[3].expectedDescendingTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
+	tests[3].equals = NewRedBlack[string, int](generic.NewCompareFunc[string](), nil)
+	tests[3].equals.Put("box", 2)
+	tests[3].equals.Put("dad", 3)
+	tests[3].equals.Put("baby", 5)
+	tests[3].equals.Put("dome", 7)
+	tests[3].equals.Put("band", 11)
+	tests[3].equals.Put("dance", 13)
+	tests[3].equals.Put("balloon", 17)
+	tests[3].expectedEquals = true
 	tests[3].expectedGraphviz = `strict digraph "Red-Black" {
   concentrate=false;
   node [style=filled, shape=oval];
@@ -120,7 +142,7 @@ func TestRedBlack(t *testing.T) {
 	tests := getRedBlackTests()
 
 	for _, tc := range tests {
-		rbt := NewRedBlack[string, int](tc.cmpKey)
+		rbt := NewRedBlack[string, int](tc.cmpKey, tc.eqVal)
 		runOrderedSymbolTableTest(t, rbt, tc)
 	}
 }

--- a/symboltable/symbol_table.go
+++ b/symboltable/symbol_table.go
@@ -47,6 +47,7 @@ type SymbolTable[K, V any] interface {
 	Get(K) (V, bool)
 	Delete(K) (V, bool)
 	KeyValues() []KeyValue[K, V]
+	Equals(SymbolTable[K, V]) bool
 }
 
 // OrderedSymbolTable represents an ordered symbol table abstract data type.

--- a/symboltable/symbol_table_test.go
+++ b/symboltable/symbol_table_test.go
@@ -13,17 +13,21 @@ type (
 		name            string
 		symbolTable     string
 		cmpKey          generic.CompareFunc[K]
+		eqVal           generic.EqualFunc[V]
 		keyVals         []KeyValue[K, V]
 		expectedSize    int
 		expectedHeight  int
 		expectedIsEmpty bool
 		expectedKeyVals []KeyValue[K, V]
+		equals          SymbolTable[K, V]
+		expectedEquals  bool
 	}
 
 	orderedSymbolTableTest[K, V any] struct {
 		name                       string
 		symbolTable                string
 		cmpKey                     generic.CompareFunc[K]
+		eqVal                      generic.EqualFunc[V]
 		keyVals                    []KeyValue[K, V]
 		expectedSize               int
 		expectedHeight             int
@@ -61,18 +65,22 @@ type (
 		expectedRLVTraverse        []KeyValue[K, V]
 		expectedAscendingTraverse  []KeyValue[K, V]
 		expectedDescendingTraverse []KeyValue[K, V]
+		equals                     OrderedSymbolTable[K, V]
+		expectedEquals             bool
 		expectedGraphviz           string
 	}
 )
 
 func getSymbolTableTests() []symbolTableTest[string, int] {
 	cmpKey := generic.NewCompareFunc[string]()
+	eqVal := generic.NewEqualFunc[int]()
 
 	return []symbolTableTest[string, int]{
 		{
 			name:            "",
 			symbolTable:     "",
 			cmpKey:          cmpKey,
+			eqVal:           eqVal,
 			keyVals:         []KeyValue[string, int]{},
 			expectedSize:    0,
 			expectedIsEmpty: true,
@@ -83,11 +91,13 @@ func getSymbolTableTests() []symbolTableTest[string, int] {
 
 func getOrderedSymbolTableTests() []orderedSymbolTableTest[string, int] {
 	cmpKey := generic.NewCompareFunc[string]()
+	eqVal := generic.NewEqualFunc[int]()
 
 	return []orderedSymbolTableTest[string, int]{
 		{
 			name:   "ABC",
 			cmpKey: cmpKey,
+			eqVal:  eqVal,
 			keyVals: []KeyValue[string, int]{
 				{"B", 2},
 				{"A", 1},
@@ -132,6 +142,7 @@ func getOrderedSymbolTableTests() []orderedSymbolTableTest[string, int] {
 		{
 			name:   "ABCDE",
 			cmpKey: cmpKey,
+			eqVal:  eqVal,
 			keyVals: []KeyValue[string, int]{
 				{"B", 2},
 				{"A", 1},
@@ -180,6 +191,7 @@ func getOrderedSymbolTableTests() []orderedSymbolTableTest[string, int] {
 		{
 			name:   "ADGJMPS",
 			cmpKey: cmpKey,
+			eqVal:  eqVal,
 			keyVals: []KeyValue[string, int]{
 				{"J", 10},
 				{"A", 1},
@@ -234,6 +246,7 @@ func getOrderedSymbolTableTests() []orderedSymbolTableTest[string, int] {
 		{
 			name:   "Words",
 			cmpKey: cmpKey,
+			eqVal:  eqVal,
 			keyVals: []KeyValue[string, int]{
 				{"box", 2},
 				{"dad", 3},
@@ -480,7 +493,7 @@ func runOrderedSymbolTableTest(t *testing.T, ost OrderedSymbolTable[string, int]
 			})
 			assert.Equal(t, test.expectedDescendingTraverse, kvs)
 
-			// Graphviz dot language code
+			assert.Equal(t, test.expectedEquals, ost.Equals(test.equals))
 			assert.Equal(t, test.expectedGraphviz, ost.Graphviz())
 
 			for _, expected := range test.keyVals {

--- a/trie/benchmark_test.go
+++ b/trie/benchmark_test.go
@@ -4,6 +4,8 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/moorara/algo/generic"
 )
 
 const (
@@ -86,13 +88,15 @@ func runDeleteBenchmark(b *testing.B, trie Trie[int]) {
 func BenchmarkTrie_Put(b *testing.B) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
+	eqVal := generic.NewEqualFunc[int]()
+
 	b.Run("BinaryTrie.Put", func(b *testing.B) {
-		trie := NewBinary[int]()
+		trie := NewBinary[int](eqVal)
 		runPutBenchmark(b, trie)
 	})
 
 	b.Run("Patricia.Put", func(b *testing.B) {
-		trie := NewPatricia[int]()
+		trie := NewPatricia[int](eqVal)
 		runPutBenchmark(b, trie)
 	})
 }
@@ -100,13 +104,15 @@ func BenchmarkTrie_Put(b *testing.B) {
 func BenchmarkTrie_Get(b *testing.B) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
+	eqVal := generic.NewEqualFunc[int]()
+
 	b.Run("BinaryTrie.Get", func(b *testing.B) {
-		trie := NewBinary[int]()
+		trie := NewBinary[int](eqVal)
 		runGetBenchmark(b, trie)
 	})
 
 	b.Run("Patricia.Get", func(b *testing.B) {
-		trie := NewPatricia[int]()
+		trie := NewPatricia[int](eqVal)
 		runGetBenchmark(b, trie)
 	})
 }
@@ -114,13 +120,15 @@ func BenchmarkTrie_Get(b *testing.B) {
 func BenchmarkTrie_Delete(b *testing.B) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
+	eqVal := generic.NewEqualFunc[int]()
+
 	b.Run("BinaryTrie.Delete", func(b *testing.B) {
-		trie := NewBinary[int]()
+		trie := NewBinary[int](eqVal)
 		runDeleteBenchmark(b, trie)
 	})
 
 	b.Run("Patricia.Delete", func(b *testing.B) {
-		trie := NewPatricia[int]()
+		trie := NewPatricia[int](eqVal)
 		runDeleteBenchmark(b, trie)
 	})
 }

--- a/trie/binary.go
+++ b/trie/binary.go
@@ -15,8 +15,9 @@ type binaryNode[V any] struct {
 }
 
 type binary[V any] struct {
-	size int
-	root *binaryNode[V]
+	size  int
+	root  *binaryNode[V]
+	eqVal generic.EqualFunc[V]
 }
 
 // NewBinaryTrie creates a new Binary Trie tree.
@@ -47,10 +48,13 @@ type binary[V any] struct {
 //	                  e*
 //
 // Includes words baby, bad, bank, box, dad, and dance.
-func NewBinary[V any]() Trie[V] {
+//
+// The second parameter (eqVal) is needed only if you want to use the Equals method.
+func NewBinary[V any](eqVal generic.EqualFunc[V]) Trie[V] {
 	return &binary[V]{
-		size: 0,
-		root: new(binaryNode[V]),
+		size:  0,
+		root:  new(binaryNode[V]),
+		eqVal: eqVal,
 	}
 }
 
@@ -100,12 +104,12 @@ func (t *binary[V]) _isRankOK() bool {
 	return true
 }
 
-// Size returns the number of key-value pairs in Trie tree.
+// Size returns the number of key-value pairs in the Binary Trie.
 func (t *binary[V]) Size() int {
 	return t.size
 }
 
-// Height returns the height of Trie tree.
+// Height returns the height of the Binary Trie.
 func (t *binary[V]) Height() int {
 	return t._height(t.root.left)
 }
@@ -118,12 +122,12 @@ func (t *binary[V]) _height(n *binaryNode[V]) int {
 	return 1 + generic.Max[int](t._height(n.left), t._height(n.right))
 }
 
-// IsEmpty returns true if Trie tree is empty.
+// IsEmpty returns true if the Binary Trie is empty.
 func (t *binary[V]) IsEmpty() bool {
 	return t.size == 0
 }
 
-// Put adds a new key-value pair to Trie tree.
+// Put adds a new key-value pair to the Binary Trie.
 func (t *binary[V]) Put(key string, val V) {
 	// Special case of empty string
 	if key == "" {
@@ -161,7 +165,7 @@ func (t *binary[V]) _put(n *binaryNode[V], key string, val V) *binaryNode[V] {
 	return n
 }
 
-// Get returns the value of a given key in Trie tree.
+// Get returns the value of a given key in the Binary Trie.
 func (t *binary[V]) Get(key string) (V, bool) {
 	// Special case of empty string
 	if key == "" {
@@ -187,7 +191,7 @@ func (t *binary[V]) _get(n *binaryNode[V], key string) (V, bool) {
 	return t._get(n.right, key)
 }
 
-// Delete removes a key-value pair from Trie tree.
+// Delete removes a key-value pair from the Binary Trie.
 func (t *binary[V]) Delete(key string) (val V, ok bool) {
 	// Special case of empty string
 	if key == "" {
@@ -224,7 +228,7 @@ func (t *binary[V]) _delete(n *binaryNode[V], key string) (*binaryNode[V], V, bo
 	return n, val, ok
 }
 
-// KeyValues returns all key-value pairs in Trie tree.
+// KeyValues returns all key-value pairs in the Binary Trie.
 func (t *binary[V]) KeyValues() []KeyValue[V] {
 	kvs := make([]KeyValue[V], 0, t.Size())
 	t._traverse(t.root.left, "", Ascending, func(k string, n *binaryNode[V]) bool {
@@ -237,7 +241,29 @@ func (t *binary[V]) KeyValues() []KeyValue[V] {
 	return kvs
 }
 
-// Min returns the minimum key and its value in Trie tree.
+// Equals determines whether or not two Binary Tries have the same key-value pairs.
+func (t *binary[V]) Equals(u Trie[V]) bool {
+	tt, ok := u.(*binary[V])
+	if !ok {
+		return false
+	}
+
+	return t._traverse(t.root.left, "", Ascending, func(k string, n *binaryNode[V]) bool { // t ⊂ tt
+		if n.term {
+			val, ok := tt.Get(k)
+			return ok && t.eqVal(n.val, val)
+		}
+		return true
+	}) && tt._traverse(tt.root.left, "", Ascending, func(k string, n *binaryNode[V]) bool { // tt ⊂ t
+		if n.term {
+			val, ok := t.Get(k)
+			return ok && t.eqVal(n.val, val)
+		}
+		return true
+	})
+}
+
+// Min returns the minimum key and its value in the Binary Trie.
 func (t *binary[V]) Min() (string, V, bool) {
 	var key string
 	var val V
@@ -254,7 +280,7 @@ func (t *binary[V]) Min() (string, V, bool) {
 	return key, val, ok
 }
 
-// Max returns the maximum key and its value in Trie tree.
+// Max returns the maximum key and its value in the Binary Trie.
 func (t *binary[V]) Max() (string, V, bool) {
 	var key string
 	var val V
@@ -271,7 +297,7 @@ func (t *binary[V]) Max() (string, V, bool) {
 	return key, val, ok
 }
 
-// Floor returns the largest key in Trie tree less than or equal to key.
+// Floor returns the largest key in the Binary Trie less than or equal to key.
 func (t *binary[V]) Floor(key string) (string, V, bool) {
 	var lastKey string
 	var lastVal V
@@ -291,7 +317,7 @@ func (t *binary[V]) Floor(key string) (string, V, bool) {
 	return lastKey, lastVal, ok
 }
 
-// Ceiling returns the smallest key in Trie tree greater than or equal to key.
+// Ceiling returns the smallest key in the Binary Trie greater than or equal to key.
 func (t *binary[V]) Ceiling(key string) (string, V, bool) {
 	var lastKey string
 	var lastVal V
@@ -311,7 +337,7 @@ func (t *binary[V]) Ceiling(key string) (string, V, bool) {
 	return lastKey, lastVal, ok
 }
 
-// DeleteMin removes the smallest key and associated value from Trie tree.
+// DeleteMin removes the smallest key and associated value from the Binary Trie.
 func (t *binary[V]) DeleteMin() (string, V, bool) {
 	key, val, ok := t.Min()
 	if !ok {
@@ -325,7 +351,7 @@ func (t *binary[V]) DeleteMin() (string, V, bool) {
 	return key, val, true
 }
 
-// DeleteMax removes the largest key and associated value from Trie tree.
+// DeleteMax removes the largest key and associated value from the Binary Trie.
 func (t *binary[V]) DeleteMax() (string, V, bool) {
 	key, val, ok := t.Max()
 	if !ok {
@@ -339,7 +365,7 @@ func (t *binary[V]) DeleteMax() (string, V, bool) {
 	return key, val, true
 }
 
-// Select returns the k-th smallest key in Trie tree.
+// Select returns the k-th smallest key in the Binary Trie.
 func (t *binary[V]) Select(rank int) (string, V, bool) {
 	var lastKey string
 	var lastVal V
@@ -366,7 +392,7 @@ func (t *binary[V]) Select(rank int) (string, V, bool) {
 	return lastKey, lastVal, ok
 }
 
-// Rank returns the number of keys in Trie tree less than key.
+// Rank returns the number of keys in the Binary Trie less than key.
 func (t *binary[V]) Rank(key string) int {
 	i := 0
 	t._traverse(t.root.left, "", Ascending, func(k string, n *binaryNode[V]) bool {
@@ -384,7 +410,7 @@ func (t *binary[V]) Rank(key string) int {
 	return i
 }
 
-// RangeSize returns the number of keys in Trie tree between two given keys.
+// RangeSize returns the number of keys in the Binary Trie between two given keys.
 func (t *binary[V]) RangeSize(lo, hi string) int {
 	i := 0
 	t._traverse(t.root.left, "", Ascending, func(k string, n *binaryNode[V]) bool {
@@ -402,7 +428,7 @@ func (t *binary[V]) RangeSize(lo, hi string) int {
 	return i
 }
 
-// Range returns all keys and associated values in Trie tree between two given keys.
+// Range returns all keys and associated values in the Binary Trie between two given keys.
 func (t *binary[V]) Range(lo, hi string) []KeyValue[V] {
 	kvs := []KeyValue[V]{}
 	t._traverse(t.root.left, "", Ascending, func(k string, n *binaryNode[V]) bool {
@@ -420,7 +446,7 @@ func (t *binary[V]) Range(lo, hi string) []KeyValue[V] {
 	return kvs
 }
 
-// Traverse is used for visiting all key-value pairs in Trie tree.
+// Traverse is used for visiting all key-value pairs in the Binary Trie.
 func (t *binary[V]) Traverse(order TraversalOrder, visit VisitFunc[V]) {
 	t._traverse(t.root, "", order, func(_ string, n *binaryNode[V]) bool {
 		// Special case of empty string
@@ -456,7 +482,7 @@ func (t *binary[V]) _traverse(n *binaryNode[V], prefix string, order TraversalOr
 	}
 }
 
-// Graphviz returns a visualization of Trie tree in Graphviz format.
+// Graphviz returns a visualization of the Binary Trie in Graphviz format.
 func (t *binary[V]) Graphviz() string {
 	// Create a map of node --> id
 	var id int

--- a/trie/binary_test.go
+++ b/trie/binary_test.go
@@ -15,7 +15,9 @@ func getBinaryTests() []trieTest[int] {
 	tests[0].expectedRLVTraverse = []KeyValue[int]{{"C", 3}, {"B", 2}, {"A", 1}, {"", 0}}
 	tests[0].expectedAscendingTraverse = []KeyValue[int]{{"", 0}, {"A", 1}, {"B", 2}, {"C", 3}}
 	tests[0].expectedDescendingTraverse = []KeyValue[int]{{"C", 3}, {"B", 2}, {"A", 1}, {"", 0}}
-	tests[0].expectedDotCode = `strict digraph "Binary Trie" {
+	tests[0].equals = nil
+	tests[0].expectedEquals = false
+	tests[0].expectedGraphviz = `strict digraph "Binary Trie" {
   concentrate=false;
   node [shape=circle];
 
@@ -39,7 +41,9 @@ func getBinaryTests() []trieTest[int] {
 	tests[1].expectedRLVTraverse = []KeyValue[int]{{"E", 5}, {"D", 4}, {"C", 3}, {"B", 2}, {"A", 1}, {"", 0}}
 	tests[1].expectedAscendingTraverse = []KeyValue[int]{{"", 0}, {"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
 	tests[1].expectedDescendingTraverse = []KeyValue[int]{{"E", 5}, {"D", 4}, {"C", 3}, {"B", 2}, {"A", 1}, {"", 0}}
-	tests[1].expectedDotCode = `strict digraph "Binary Trie" {
+	tests[1].equals = NewBinary[int](nil)
+	tests[1].expectedEquals = false
+	tests[1].expectedGraphviz = `strict digraph "Binary Trie" {
   concentrate=false;
   node [shape=circle];
 
@@ -67,7 +71,12 @@ func getBinaryTests() []trieTest[int] {
 	tests[2].expectedRLVTraverse = []KeyValue[int]{{"S", 19}, {"P", 16}, {"M", 13}, {"J", 10}, {"G", 7}, {"D", 4}, {"A", 1}, {"", 0}}
 	tests[2].expectedAscendingTraverse = []KeyValue[int]{{"", 0}, {"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
 	tests[2].expectedDescendingTraverse = []KeyValue[int]{{"S", 19}, {"P", 16}, {"M", 13}, {"J", 10}, {"G", 7}, {"D", 4}, {"A", 1}, {"", 0}}
-	tests[2].expectedDotCode = `strict digraph "Binary Trie" {
+	tests[2].equals = NewBinary[int](nil)
+	tests[2].equals.Put("A", 1)
+	tests[2].equals.Put("D", 4)
+	tests[2].equals.Put("G", 7)
+	tests[2].expectedEquals = false
+	tests[2].expectedGraphviz = `strict digraph "Binary Trie" {
   concentrate=false;
   node [shape=circle];
 
@@ -99,7 +108,16 @@ func getBinaryTests() []trieTest[int] {
 	tests[3].expectedRLVTraverse = []KeyValue[int]{{"e", 7}, {"m", 0}, {"o", 0}, {"e", 13}, {"c", 0}, {"n", 0}, {"d", 3}, {"a", 0}, {"d", 0}, {"x", 2}, {"o", 0}, {"d", 11}, {"n", 0}, {"n", 17}, {"o", 0}, {"o", 0}, {"l", 0}, {"l", 0}, {"y", 5}, {"b", 0}, {"a", 0}, {"b", 0}, {"", 0}}
 	tests[3].expectedAscendingTraverse = []KeyValue[int]{{"", 0}, {"b", 0}, {"a", 0}, {"b", 0}, {"y", 5}, {"l", 0}, {"l", 0}, {"o", 0}, {"o", 0}, {"n", 17}, {"n", 0}, {"d", 11}, {"o", 0}, {"x", 2}, {"d", 0}, {"a", 0}, {"d", 3}, {"n", 0}, {"c", 0}, {"e", 13}, {"o", 0}, {"m", 0}, {"e", 7}}
 	tests[3].expectedDescendingTraverse = []KeyValue[int]{{"e", 7}, {"m", 0}, {"o", 0}, {"e", 13}, {"c", 0}, {"n", 0}, {"d", 3}, {"a", 0}, {"d", 0}, {"x", 2}, {"o", 0}, {"d", 11}, {"n", 0}, {"n", 17}, {"o", 0}, {"o", 0}, {"l", 0}, {"l", 0}, {"y", 5}, {"b", 0}, {"a", 0}, {"b", 0}, {"", 0}}
-	tests[3].expectedDotCode = `strict digraph "Binary Trie" {
+	tests[3].equals = NewBinary[int](nil)
+	tests[3].equals.Put("box", 2)
+	tests[3].equals.Put("dad", 3)
+	tests[3].equals.Put("baby", 5)
+	tests[3].equals.Put("dome", 7)
+	tests[3].equals.Put("band", 11)
+	tests[3].equals.Put("dance", 13)
+	tests[3].equals.Put("balloon", 17)
+	tests[3].expectedEquals = true
+	tests[3].expectedGraphviz = `strict digraph "Binary Trie" {
   concentrate=false;
   node [shape=circle];
 
@@ -158,7 +176,7 @@ func TestBinaryTrie(t *testing.T) {
 	tests := getBinaryTests()
 
 	for _, tc := range tests {
-		bin := NewBinary[int]()
+		bin := NewBinary[int](tc.eqVal)
 		runTrieTest(t, bin, tc)
 	}
 }

--- a/trie/patricia_test.go
+++ b/trie/patricia_test.go
@@ -15,7 +15,9 @@ func getPatriciaTests() []trieTest[int] {
 	tests[0].expectedRLVTraverse = []KeyValue[int]{{"C", 3}, {"A", 1}, {"B", 2}}
 	tests[0].expectedAscendingTraverse = []KeyValue[int]{{"A", 1}, {"B", 2}, {"C", 3}}
 	tests[0].expectedDescendingTraverse = []KeyValue[int]{{"C", 3}, {"B", 2}, {"A", 1}}
-	tests[0].expectedDotCode = `strict digraph "Patricia" {
+	tests[0].equals = nil
+	tests[0].expectedEquals = false
+	tests[0].expectedGraphviz = `strict digraph "Patricia" {
   rankdir=TB;
   concentrate=false;
   node [shape=Mrecord];
@@ -41,7 +43,9 @@ func getPatriciaTests() []trieTest[int] {
 	tests[1].expectedRLVTraverse = []KeyValue[int]{{"E", 5}, {"C", 3}, {"A", 1}, {"D", 4}, {"B", 2}}
 	tests[1].expectedAscendingTraverse = []KeyValue[int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
 	tests[1].expectedDescendingTraverse = []KeyValue[int]{{"E", 5}, {"D", 4}, {"C", 3}, {"B", 2}, {"A", 1}}
-	tests[1].expectedDotCode = `strict digraph "Patricia" {
+	tests[1].equals = NewPatricia[int](nil)
+	tests[1].expectedEquals = false
+	tests[1].expectedGraphviz = `strict digraph "Patricia" {
   rankdir=TB;
   concentrate=false;
   node [shape=Mrecord];
@@ -73,7 +77,12 @@ func getPatriciaTests() []trieTest[int] {
 	tests[2].expectedRLVTraverse = []KeyValue[int]{{"S", 19}, {"M", 13}, {"G", 7}, {"A", 1}, {"D", 4}, {"P", 16}, {"J", 10}}
 	tests[2].expectedAscendingTraverse = []KeyValue[int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
 	tests[2].expectedDescendingTraverse = []KeyValue[int]{{"S", 19}, {"P", 16}, {"M", 13}, {"J", 10}, {"G", 7}, {"D", 4}, {"A", 1}}
-	tests[2].expectedDotCode = `strict digraph "Patricia" {
+	tests[2].equals = NewPatricia[int](nil)
+	tests[2].equals.Put("A", 1)
+	tests[2].equals.Put("D", 4)
+	tests[2].equals.Put("G", 7)
+	tests[2].expectedEquals = false
+	tests[2].expectedGraphviz = `strict digraph "Patricia" {
   rankdir=TB;
   concentrate=false;
   node [shape=Mrecord];
@@ -111,7 +120,16 @@ func getPatriciaTests() []trieTest[int] {
 	tests[3].expectedRLVTraverse = []KeyValue[int]{{"dance", 13}, {"dome", 7}, {"balloon", 17}, {"baby", 5}, {"band", 11}, {"dad", 3}, {"box", 2}}
 	tests[3].expectedAscendingTraverse = []KeyValue[int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
 	tests[3].expectedDescendingTraverse = []KeyValue[int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
-	tests[3].expectedDotCode = `strict digraph "Patricia" {
+	tests[3].equals = NewPatricia[int](nil)
+	tests[3].equals.Put("box", 2)
+	tests[3].equals.Put("dad", 3)
+	tests[3].equals.Put("baby", 5)
+	tests[3].equals.Put("dome", 7)
+	tests[3].equals.Put("band", 11)
+	tests[3].equals.Put("dance", 13)
+	tests[3].equals.Put("balloon", 17)
+	tests[3].expectedEquals = true
+	tests[3].expectedGraphviz = `strict digraph "Patricia" {
   rankdir=TB;
   concentrate=false;
   node [shape=Mrecord];
@@ -146,7 +164,7 @@ func TestPatricia(t *testing.T) {
 	tests := getPatriciaTests()
 
 	for _, tc := range tests {
-		pat := NewPatricia[int]()
+		pat := NewPatricia[int](tc.eqVal)
 		runTrieTest(t, pat, tc)
 	}
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -44,6 +44,7 @@ type Trie[V any] interface {
 	Get(string) (V, bool)
 	Delete(string) (V, bool)
 	KeyValues() []KeyValue[V]
+	Equals(Trie[V]) bool
 
 	Min() (string, V, bool)
 	Max() (string, V, bool)

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -4,11 +4,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/moorara/algo/generic"
 )
 
 type trieTest[V any] struct {
 	name                       string
 	symbolTable                string
+	eqVal                      generic.EqualFunc[V]
 	keyVals                    []KeyValue[V]
 	expectedSize               int
 	expectedHeight             int
@@ -46,7 +49,9 @@ type trieTest[V any] struct {
 	expectedRLVTraverse        []KeyValue[V]
 	expectedAscendingTraverse  []KeyValue[V]
 	expectedDescendingTraverse []KeyValue[V]
-	expectedDotCode            string
+	equals                     Trie[V]
+	expectedEquals             bool
+	expectedGraphviz           string
 	matchPattern               string
 	expectedMatch              []KeyValue[V]
 	withPrefixKey              string
@@ -58,9 +63,12 @@ type trieTest[V any] struct {
 }
 
 func getTrieTests() []trieTest[int] {
+	eqVal := generic.NewEqualFunc[int]()
+
 	return []trieTest[int]{
 		{
-			name: "ABC",
+			name:  "ABC",
+			eqVal: eqVal,
 			keyVals: []KeyValue[int]{
 				{"B", 2},
 				{"A", 1},
@@ -117,7 +125,8 @@ func getTrieTests() []trieTest[int] {
 			expectedLongestPrefixOfOK:  false,
 		},
 		{
-			name: "ABCDE",
+			name:  "ABCDE",
+			eqVal: eqVal,
 			keyVals: []KeyValue[int]{
 				{"B", 2},
 				{"A", 1},
@@ -180,7 +189,8 @@ func getTrieTests() []trieTest[int] {
 			expectedLongestPrefixOfOK:  true,
 		},
 		{
-			name: "ADGJMPS",
+			name:  "ADGJMPS",
+			eqVal: eqVal,
 			keyVals: []KeyValue[int]{
 				{"J", 10},
 				{"A", 1},
@@ -251,7 +261,8 @@ func getTrieTests() []trieTest[int] {
 			expectedLongestPrefixOfOK:  true,
 		},
 		{
-			name: "Words",
+			name:  "Words",
+			eqVal: eqVal,
 			keyVals: []KeyValue[int]{
 				{"box", 2},
 				{"dad", 3},
@@ -493,8 +504,8 @@ func runTrieTest(t *testing.T, trie Trie[int], test trieTest[int]) {
 			})
 			assert.Equal(t, test.expectedDescendingTraverse, kvs)
 
-			// Graphviz dot language code
-			assert.Equal(t, test.expectedDotCode, trie.Graphviz())
+			assert.Equal(t, test.expectedEquals, trie.Equals(test.equals))
+			assert.Equal(t, test.expectedGraphviz, trie.Graphviz())
 
 			kvs = trie.Match(test.matchPattern)
 			assert.Equal(t, test.expectedMatch, kvs)


### PR DESCRIPTION
## Description

  - [x] Add `Equals` to `SymbolTable` interface
  - [x] Add `Equals` to `Trie` interface

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
