### PR TITLE
Add Equals to DFA/NFA APIs

### DIFF
--- a/automata/dfa.go
+++ b/automata/dfa.go
@@ -126,6 +126,13 @@ func (d *DFA) Accept(s String) bool {
 	return d.Final.Contains(curr)
 }
 
+// Equals determines whether or not two DFAs are the same.
+func (d *DFA) Equals(dfa *DFA) bool {
+	return d.Start == dfa.Start &&
+		d.Final.Equals(dfa.Final) &&
+		d.trans.Equals(dfa.trans)
+}
+
 // Graphviz returns the transition graph of the DFA in DOT Language format.
 func (d *DFA) Graphviz() string {
 	graph := graphviz.NewGraph(true, true, false, "DFA", graphviz.RankDirLR, "", "", "")

--- a/automata/dfa_test.go
+++ b/automata/dfa_test.go
@@ -285,6 +285,36 @@ func TestDFA_Accept(t *testing.T) {
 	}
 }
 
+func TestDFA_Equals(t *testing.T) {
+	dfas := getTestDFAs()
+
+	tests := []struct {
+		name           string
+		d              *DFA
+		dfa            *DFA
+		expectedEquals bool
+	}{
+		{
+			name:           "Equal",
+			d:              dfas[0],
+			dfa:            dfas[0],
+			expectedEquals: true,
+		},
+		{
+			name:           "NotEqual",
+			d:              dfas[1],
+			dfa:            dfas[2],
+			expectedEquals: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedEquals, tc.d.Equals(tc.dfa))
+		})
+	}
+}
+
 func TestDFA_Graphviz(t *testing.T) {
 	dfas := getTestDFAs()
 

--- a/automata/nfa.go
+++ b/automata/nfa.go
@@ -217,6 +217,13 @@ func (n *NFA) ToDFA() *DFA {
 	return dfa
 }
 
+// Equals determines whether or not two NFAs are the same.
+func (n *NFA) Equals(nfa *NFA) bool {
+	return n.Start == nfa.Start &&
+		n.Final.Equals(nfa.Final) &&
+		n.trans.Equals(nfa.trans)
+}
+
 // Graphviz returns the transition graph of the NFA in DOT Language format.
 func (n *NFA) Graphviz() string {
 	graph := graphviz.NewGraph(true, true, false, "NFA", graphviz.RankDirLR, "", "", graphviz.ShapeCircle)

--- a/automata/nfa_test.go
+++ b/automata/nfa_test.go
@@ -307,6 +307,36 @@ func TestNFA_ToDFA(t *testing.T) {
 	}
 }
 
+func TestNFA_Equals(t *testing.T) {
+	nfas := getTestNFAs()
+
+	tests := []struct {
+		name           string
+		n              *NFA
+		nfa            *NFA
+		expectedEquals bool
+	}{
+		{
+			name:           "Equal",
+			n:              nfas[0],
+			nfa:            nfas[0],
+			expectedEquals: true,
+		},
+		{
+			name:           "NotEqual",
+			n:              nfas[1],
+			nfa:            nfas[2],
+			expectedEquals: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedEquals, tc.n.Equals(tc.nfa))
+		})
+	}
+}
+
 func TestNFA_Graphviz(t *testing.T) {
 	nfas := getTestNFAs()
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.0
-	golang.org/x/exp v0.0.0-20221012211006-4de253d81b95
+	golang.org/x/exp v0.0.0-20221018221608-02f3b879a704
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-golang.org/x/exp v0.0.0-20221012211006-4de253d81b95 h1:sBdrWpxhGDdTAYNqbgBLAR+ULAPPhfgncLr1X0lyWtg=
-golang.org/x/exp v0.0.0-20221012211006-4de253d81b95/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20221018221608-02f3b879a704 h1:qeTd8Mtg7Z9G839eB0/DhF2vU3ZeXcP6vwAY/IqVRPM=
+golang.org/x/exp v0.0.0-20221018221608-02f3b879a704/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Description

  - [x] Add `Equals` to `DFA` methods
  - [x] Add `Equals` to `NFA` methods

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
