### PR TITLE
Add Select and Map to set API

### DIFF
--- a/set/map.go
+++ b/set/map.go
@@ -1,0 +1,18 @@
+package set
+
+import "github.com/moorara/algo/generic"
+
+// Mapper
+type Mapper[T, U any] func(T) U
+
+func (f Mapper[T, U]) Map(s Set[T], equal generic.EqualFunc[U]) Set[U] {
+	members := make([]U, 0)
+	for _, m := range s.Members() {
+		members = append(members, f(m))
+	}
+
+	return &set[U]{
+		equal:   equal,
+		members: members,
+	}
+}

--- a/set/map_test.go
+++ b/set/map_test.go
@@ -1,0 +1,56 @@
+package set
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moorara/algo/generic"
+)
+
+func TestMapper_Map(t *testing.T) {
+	eqFunc := generic.NewEqualFunc[string]()
+	mapper := func(s string) string {
+		return strings.ToUpper(s)
+	}
+
+	tests := []struct {
+		name     string
+		f        Mapper[string, string]
+		s        *set[string]
+		expected Set[string]
+	}{
+		{
+			name: "Empty",
+			f:    mapper,
+			s: &set[string]{
+				equal:   eqFunc,
+				members: []string{},
+			},
+			expected: &set[string]{
+				equal:   eqFunc,
+				members: []string{},
+			},
+		},
+		{
+			name: "NonEmpty",
+			f:    mapper,
+			s: &set[string]{
+				equal:   eqFunc,
+				members: []string{"a", "b", "c", "d"},
+			},
+			expected: &set[string]{
+				equal:   eqFunc,
+				members: []string{"A", "B", "C", "D"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			set := tc.f.Map(tc.s, eqFunc)
+			assert.True(t, set.Equals(tc.expected))
+		})
+	}
+}

--- a/set/set.go
+++ b/set/set.go
@@ -25,6 +25,7 @@ type Set[T any] interface {
 	Members() []T
 	Clone() Set[T]
 	CloneEmpty() Set[T]
+	Select(Predicate[T]) Set[T]
 	Union(...Set[T]) Set[T]
 	Intersection(...Set[T]) Set[T]
 	Difference(...Set[T]) Set[T]
@@ -148,6 +149,20 @@ func (s *set[T]) CloneEmpty() Set[T] {
 	}
 
 	return t
+}
+
+func (s *set[T]) Select(p Predicate[T]) Set[T] {
+	members := make([]T, 0)
+	for _, m := range s.members {
+		if p(m) {
+			members = append(members, m)
+		}
+	}
+
+	return &set[T]{
+		equal:   s.equal,
+		members: members,
+	}
 }
 
 func (s *set[T]) Union(sets ...Set[T]) Set[T] {

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -466,6 +466,64 @@ func TestSet_CloneEmpty(t *testing.T) {
 	}
 }
 
+func TestSet_Select(t *testing.T) {
+	eqFunc := generic.NewEqualFunc[string]()
+	predicate := func(s string) bool {
+		return strings.ToUpper(s) == s
+	}
+
+	tests := []struct {
+		name     string
+		s        *set[string]
+		p        Predicate[string]
+		expected Set[string]
+	}{
+		{
+			name: "Empty",
+			s: &set[string]{
+				equal:   eqFunc,
+				members: []string{},
+			},
+			p: predicate,
+			expected: &set[string]{
+				equal:   eqFunc,
+				members: []string{},
+			},
+		},
+		{
+			name: "SelectNone",
+			s: &set[string]{
+				equal:   eqFunc,
+				members: []string{"a", "b", "c", "d"},
+			},
+			p: predicate,
+			expected: &set[string]{
+				equal:   eqFunc,
+				members: []string{},
+			},
+		},
+		{
+			name: "SelectSome",
+			s: &set[string]{
+				equal:   eqFunc,
+				members: []string{"A", "c", "C", "d"},
+			},
+			p: predicate,
+			expected: &set[string]{
+				equal:   eqFunc,
+				members: []string{"A", "C"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			set := tc.s.Select(tc.p)
+			assert.True(t, set.Equals(tc.expected))
+		})
+	}
+}
+
 func TestSet_Union(t *testing.T) {
 	eqFunc := generic.NewEqualFunc[string]()
 


### PR DESCRIPTION
<!--
  If this pull request addresses an issue, make sure your description includes "Resolves #xx", "Fixes #xx", or "Closes #xx".
  See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Description

  - [x] Add `Select` method to `set.Set` API
  - [x] Add `Map` function to `set` package

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
