### PR TITLE
Add Any and All to Symbol Table API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/moorara/algo
 
-go 1.22.2
+go 1.23.3
 
 require (
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
+	golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f h1:99ci1mjWVBWwJiEKYY6jWa4d2nTQVIEhZIptnrVb1XY=
-golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
+golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d h1:0olWaB5pg3+oychR51GUVCEsGkeCU/2JxjBgIo4f3M0=
+golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/symboltable/avl.go
+++ b/symboltable/avl.go
@@ -301,6 +301,20 @@ func (t *avl[K, V]) Equals(u SymbolTable[K, V]) bool {
 	})
 }
 
+// Any returns true if any of the key-value pairs in the AVL tree satisfy the given predicate.
+func (t *avl[K, V]) Any(p Predicate[K, V]) bool {
+	return !t._traverse(t.root, VLR, func(n *avlNode[K, V]) bool {
+		return !p(n.key, n.val)
+	})
+}
+
+// All returns true if all key-value pairs in the AVL tree satisfy a given predicate.
+func (t *avl[K, V]) All(p Predicate[K, V]) bool {
+	return t._traverse(t.root, VLR, func(n *avlNode[K, V]) bool {
+		return p(n.key, n.val)
+	})
+}
+
 // Min returns the minimum key and its value in the AVL tree.
 func (t *avl[K, V]) Min() (K, V, bool) {
 	if t.root == nil {

--- a/symboltable/avl_test.go
+++ b/symboltable/avl_test.go
@@ -11,6 +11,8 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 
 	tests[0].symbolTable = "AVL"
 	tests[0].expectedHeight = 2
+	tests[0].equals = nil
+	tests[0].expectedEquals = false
 	tests[0].expectedVLRTraverse = []KeyValue[string, int]{{"B", 2}, {"A", 1}, {"C", 3}}
 	tests[0].expectedVRLTraverse = []KeyValue[string, int]{{"B", 2}, {"C", 3}, {"A", 1}}
 	tests[0].expectedLVRTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}}
@@ -19,8 +21,6 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 	tests[0].expectedRLVTraverse = []KeyValue[string, int]{{"C", 3}, {"A", 1}, {"B", 2}}
 	tests[0].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}}
 	tests[0].expectedDescendingTraverse = []KeyValue[string, int]{{"C", 3}, {"B", 2}, {"A", 1}}
-	tests[0].equals = nil
-	tests[0].expectedEquals = false
 	tests[0].expectedGraphviz = `strict digraph "AVL" {
   concentrate=false;
   node [shape=oval];
@@ -35,6 +35,8 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 
 	tests[1].symbolTable = "AVL"
 	tests[1].expectedHeight = 3
+	tests[1].equals = NewAVL[string, int](generic.NewCompareFunc[string](), nil)
+	tests[1].expectedEquals = false
 	tests[1].expectedVLRTraverse = []KeyValue[string, int]{{"B", 2}, {"A", 1}, {"D", 4}, {"C", 3}, {"E", 5}}
 	tests[1].expectedVRLTraverse = []KeyValue[string, int]{{"B", 2}, {"D", 4}, {"E", 5}, {"C", 3}, {"A", 1}}
 	tests[1].expectedLVRTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
@@ -43,8 +45,6 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 	tests[1].expectedRLVTraverse = []KeyValue[string, int]{{"E", 5}, {"C", 3}, {"D", 4}, {"A", 1}, {"B", 2}}
 	tests[1].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
 	tests[1].expectedDescendingTraverse = []KeyValue[string, int]{{"E", 5}, {"D", 4}, {"C", 3}, {"B", 2}, {"A", 1}}
-	tests[1].equals = NewAVL[string, int](generic.NewCompareFunc[string](), nil)
-	tests[1].expectedEquals = false
 	tests[1].expectedGraphviz = `strict digraph "AVL" {
   concentrate=false;
   node [shape=oval];
@@ -63,6 +63,11 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 
 	tests[2].symbolTable = "AVL"
 	tests[2].expectedHeight = 3
+	tests[2].equals = NewAVL[string, int](generic.NewCompareFunc[string](), nil)
+	tests[2].equals.Put("D", 4)
+	tests[2].equals.Put("J", 10)
+	tests[2].equals.Put("P", 16)
+	tests[2].expectedEquals = false
 	tests[2].expectedVLRTraverse = []KeyValue[string, int]{{"J", 10}, {"D", 4}, {"A", 1}, {"G", 7}, {"P", 16}, {"M", 13}, {"S", 19}}
 	tests[2].expectedVRLTraverse = []KeyValue[string, int]{{"J", 10}, {"P", 16}, {"S", 19}, {"M", 13}, {"D", 4}, {"G", 7}, {"A", 1}}
 	tests[2].expectedLVRTraverse = []KeyValue[string, int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
@@ -71,11 +76,6 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 	tests[2].expectedRLVTraverse = []KeyValue[string, int]{{"S", 19}, {"M", 13}, {"P", 16}, {"G", 7}, {"A", 1}, {"D", 4}, {"J", 10}}
 	tests[2].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
 	tests[2].expectedDescendingTraverse = []KeyValue[string, int]{{"S", 19}, {"P", 16}, {"M", 13}, {"J", 10}, {"G", 7}, {"D", 4}, {"A", 1}}
-	tests[2].equals = NewAVL[string, int](generic.NewCompareFunc[string](), nil)
-	tests[2].equals.Put("D", 4)
-	tests[2].equals.Put("J", 10)
-	tests[2].equals.Put("P", 16)
-	tests[2].expectedEquals = false
 	tests[2].expectedGraphviz = `strict digraph "AVL" {
   concentrate=false;
   node [shape=oval];
@@ -98,14 +98,6 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 
 	tests[3].symbolTable = "AVL"
 	tests[3].expectedHeight = 3
-	tests[3].expectedVLRTraverse = []KeyValue[string, int]{{"box", 2}, {"balloon", 17}, {"baby", 5}, {"band", 11}, {"dance", 13}, {"dad", 3}, {"dome", 7}}
-	tests[3].expectedVRLTraverse = []KeyValue[string, int]{{"box", 2}, {"dance", 13}, {"dome", 7}, {"dad", 3}, {"balloon", 17}, {"band", 11}, {"baby", 5}}
-	tests[3].expectedLVRTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
-	tests[3].expectedRVLTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
-	tests[3].expectedLRVTraverse = []KeyValue[string, int]{{"baby", 5}, {"band", 11}, {"balloon", 17}, {"dad", 3}, {"dome", 7}, {"dance", 13}, {"box", 2}}
-	tests[3].expectedRLVTraverse = []KeyValue[string, int]{{"dome", 7}, {"dad", 3}, {"dance", 13}, {"band", 11}, {"baby", 5}, {"balloon", 17}, {"box", 2}}
-	tests[3].expectedAscendingTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
-	tests[3].expectedDescendingTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
 	tests[3].equals = NewAVL[string, int](generic.NewCompareFunc[string](), nil)
 	tests[3].equals.Put("box", 2)
 	tests[3].equals.Put("dad", 3)
@@ -115,6 +107,14 @@ func getAVLTests() []orderedSymbolTableTest[string, int] {
 	tests[3].equals.Put("dance", 13)
 	tests[3].equals.Put("balloon", 17)
 	tests[3].expectedEquals = true
+	tests[3].expectedVLRTraverse = []KeyValue[string, int]{{"box", 2}, {"balloon", 17}, {"baby", 5}, {"band", 11}, {"dance", 13}, {"dad", 3}, {"dome", 7}}
+	tests[3].expectedVRLTraverse = []KeyValue[string, int]{{"box", 2}, {"dance", 13}, {"dome", 7}, {"dad", 3}, {"balloon", 17}, {"band", 11}, {"baby", 5}}
+	tests[3].expectedLVRTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
+	tests[3].expectedRVLTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
+	tests[3].expectedLRVTraverse = []KeyValue[string, int]{{"baby", 5}, {"band", 11}, {"balloon", 17}, {"dad", 3}, {"dome", 7}, {"dance", 13}, {"box", 2}}
+	tests[3].expectedRLVTraverse = []KeyValue[string, int]{{"dome", 7}, {"dad", 3}, {"dance", 13}, {"band", 11}, {"baby", 5}, {"balloon", 17}, {"box", 2}}
+	tests[3].expectedAscendingTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
+	tests[3].expectedDescendingTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
 	tests[3].expectedGraphviz = `strict digraph "AVL" {
   concentrate=false;
   node [shape=oval];

--- a/symboltable/bst.go
+++ b/symboltable/bst.go
@@ -239,6 +239,20 @@ func (t *bst[K, V]) Equals(u SymbolTable[K, V]) bool {
 	})
 }
 
+// Any returns true if any of the key-value pairs in the BST satisfy the given predicate.
+func (t *bst[K, V]) Any(p Predicate[K, V]) bool {
+	return !t._traverse(t.root, VLR, func(n *bstNode[K, V]) bool {
+		return !p(n.key, n.val)
+	})
+}
+
+// All returns true if all key-value pairs in the BST satisfy a given predicate.
+func (t *bst[K, V]) All(p Predicate[K, V]) bool {
+	return t._traverse(t.root, VLR, func(n *bstNode[K, V]) bool {
+		return p(n.key, n.val)
+	})
+}
+
 // Min returns the minimum key and its value in the BST.
 func (t *bst[K, V]) Min() (K, V, bool) {
 	if t.root == nil {

--- a/symboltable/bst_test.go
+++ b/symboltable/bst_test.go
@@ -11,6 +11,8 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 
 	tests[0].symbolTable = "BST"
 	tests[0].expectedHeight = 2
+	tests[0].equals = nil
+	tests[0].expectedEquals = false
 	tests[0].expectedVLRTraverse = []KeyValue[string, int]{{"B", 2}, {"A", 1}, {"C", 3}}
 	tests[0].expectedVRLTraverse = []KeyValue[string, int]{{"B", 2}, {"C", 3}, {"A", 1}}
 	tests[0].expectedLVRTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}}
@@ -19,8 +21,6 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 	tests[0].expectedRLVTraverse = []KeyValue[string, int]{{"C", 3}, {"A", 1}, {"B", 2}}
 	tests[0].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}}
 	tests[0].expectedDescendingTraverse = []KeyValue[string, int]{{"C", 3}, {"B", 2}, {"A", 1}}
-	tests[0].equals = nil
-	tests[0].expectedEquals = false
 	tests[0].expectedGraphviz = `strict digraph "BST" {
   concentrate=false;
   node [shape=oval];
@@ -35,6 +35,8 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 
 	tests[1].symbolTable = "BST"
 	tests[1].expectedHeight = 4
+	tests[1].equals = NewBST[string, int](generic.NewCompareFunc[string](), nil)
+	tests[1].expectedEquals = false
 	tests[1].expectedVLRTraverse = []KeyValue[string, int]{{"B", 2}, {"A", 1}, {"C", 3}, {"D", 4}, {"E", 5}}
 	tests[1].expectedVRLTraverse = []KeyValue[string, int]{{"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}, {"A", 1}}
 	tests[1].expectedLVRTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
@@ -43,8 +45,6 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 	tests[1].expectedRLVTraverse = []KeyValue[string, int]{{"E", 5}, {"D", 4}, {"C", 3}, {"A", 1}, {"B", 2}}
 	tests[1].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
 	tests[1].expectedDescendingTraverse = []KeyValue[string, int]{{"E", 5}, {"D", 4}, {"C", 3}, {"B", 2}, {"A", 1}}
-	tests[1].equals = NewBST[string, int](generic.NewCompareFunc[string](), nil)
-	tests[1].expectedEquals = false
 	tests[1].expectedGraphviz = `strict digraph "BST" {
   concentrate=false;
   node [shape=oval];
@@ -63,6 +63,11 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 
 	tests[2].symbolTable = "BST"
 	tests[2].expectedHeight = 4
+	tests[2].equals = NewBST[string, int](generic.NewCompareFunc[string](), nil)
+	tests[2].equals.Put("J", 10)
+	tests[2].equals.Put("D", 4)
+	tests[2].equals.Put("P", 16)
+	tests[2].expectedEquals = false
 	tests[2].expectedVLRTraverse = []KeyValue[string, int]{{"J", 10}, {"D", 4}, {"A", 1}, {"G", 7}, {"P", 16}, {"M", 13}, {"S", 19}}
 	tests[2].expectedVRLTraverse = []KeyValue[string, int]{{"J", 10}, {"P", 16}, {"S", 19}, {"M", 13}, {"D", 4}, {"G", 7}, {"A", 1}}
 	tests[2].expectedLVRTraverse = []KeyValue[string, int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
@@ -71,11 +76,6 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 	tests[2].expectedRLVTraverse = []KeyValue[string, int]{{"S", 19}, {"M", 13}, {"P", 16}, {"G", 7}, {"A", 1}, {"D", 4}, {"J", 10}}
 	tests[2].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
 	tests[2].expectedDescendingTraverse = []KeyValue[string, int]{{"S", 19}, {"P", 16}, {"M", 13}, {"J", 10}, {"G", 7}, {"D", 4}, {"A", 1}}
-	tests[2].equals = NewBST[string, int](generic.NewCompareFunc[string](), nil)
-	tests[2].equals.Put("J", 10)
-	tests[2].equals.Put("D", 4)
-	tests[2].equals.Put("P", 16)
-	tests[2].expectedEquals = false
 	tests[2].expectedGraphviz = `strict digraph "BST" {
   concentrate=false;
   node [shape=oval];
@@ -98,14 +98,6 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 
 	tests[3].symbolTable = "BST"
 	tests[3].expectedHeight = 4
-	tests[3].expectedVLRTraverse = []KeyValue[string, int]{{"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
-	tests[3].expectedVRLTraverse = []KeyValue[string, int]{{"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
-	tests[3].expectedLVRTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
-	tests[3].expectedRVLTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
-	tests[3].expectedLRVTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}}
-	tests[3].expectedRLVTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}}
-	tests[3].expectedAscendingTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
-	tests[3].expectedDescendingTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
 	tests[3].equals = NewBST[string, int](generic.NewCompareFunc[string](), nil)
 	tests[3].equals.Put("box", 2)
 	tests[3].equals.Put("band", 11)
@@ -115,6 +107,14 @@ func getBSTTests() []orderedSymbolTableTest[string, int] {
 	tests[3].equals.Put("dance", 13)
 	tests[3].equals.Put("dome", 7)
 	tests[3].expectedEquals = true
+	tests[3].expectedVLRTraverse = []KeyValue[string, int]{{"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
+	tests[3].expectedVRLTraverse = []KeyValue[string, int]{{"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
+	tests[3].expectedLVRTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
+	tests[3].expectedRVLTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
+	tests[3].expectedLRVTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}}
+	tests[3].expectedRLVTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}}
+	tests[3].expectedAscendingTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
+	tests[3].expectedDescendingTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
 	tests[3].expectedGraphviz = `strict digraph "BST" {
   concentrate=false;
   node [shape=oval];

--- a/symboltable/red_black.go
+++ b/symboltable/red_black.go
@@ -409,6 +409,20 @@ func (t *redBlack[K, V]) Equals(u SymbolTable[K, V]) bool {
 	})
 }
 
+// Any returns true if any of the key-value pairs in the Red-Black tree satisfy the given predicate.
+func (t *redBlack[K, V]) Any(p Predicate[K, V]) bool {
+	return !t._traverse(t.root, VLR, func(n *rbNode[K, V]) bool {
+		return !p(n.key, n.val)
+	})
+}
+
+// All returns true if all key-value pairs in the Red-Black tree satisfy a given predicate.
+func (t *redBlack[K, V]) All(p Predicate[K, V]) bool {
+	return t._traverse(t.root, VLR, func(n *rbNode[K, V]) bool {
+		return p(n.key, n.val)
+	})
+}
+
 // Min returns the minimum key and its value in the Red-Black tree.
 func (t *redBlack[K, V]) Min() (K, V, bool) {
 	if t.root == nil {

--- a/symboltable/red_black_test.go
+++ b/symboltable/red_black_test.go
@@ -11,6 +11,8 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 
 	tests[0].symbolTable = "LLRB Tree"
 	tests[0].expectedHeight = 2
+	tests[0].equals = nil
+	tests[0].expectedEquals = false
 	tests[0].expectedVLRTraverse = []KeyValue[string, int]{{"B", 2}, {"A", 1}, {"C", 3}}
 	tests[0].expectedVRLTraverse = []KeyValue[string, int]{{"B", 2}, {"C", 3}, {"A", 1}}
 	tests[0].expectedLVRTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}}
@@ -19,8 +21,6 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 	tests[0].expectedRLVTraverse = []KeyValue[string, int]{{"C", 3}, {"A", 1}, {"B", 2}}
 	tests[0].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}}
 	tests[0].expectedDescendingTraverse = []KeyValue[string, int]{{"C", 3}, {"B", 2}, {"A", 1}}
-	tests[0].equals = nil
-	tests[0].expectedEquals = false
 	tests[0].expectedGraphviz = `strict digraph "Red-Black" {
   concentrate=false;
   node [style=filled, shape=oval];
@@ -35,6 +35,8 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 
 	tests[1].symbolTable = "LLRB Tree"
 	tests[1].expectedHeight = 3
+	tests[1].equals = NewRedBlack[string, int](generic.NewCompareFunc[string](), nil)
+	tests[1].expectedEquals = false
 	tests[1].expectedVLRTraverse = []KeyValue[string, int]{{"D", 4}, {"B", 2}, {"A", 1}, {"C", 3}, {"E", 5}}
 	tests[1].expectedVRLTraverse = []KeyValue[string, int]{{"D", 4}, {"E", 5}, {"B", 2}, {"C", 3}, {"A", 1}}
 	tests[1].expectedLVRTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
@@ -43,8 +45,6 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 	tests[1].expectedRLVTraverse = []KeyValue[string, int]{{"E", 5}, {"C", 3}, {"A", 1}, {"B", 2}, {"D", 4}}
 	tests[1].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}, {"E", 5}}
 	tests[1].expectedDescendingTraverse = []KeyValue[string, int]{{"E", 5}, {"D", 4}, {"C", 3}, {"B", 2}, {"A", 1}}
-	tests[1].equals = NewRedBlack[string, int](generic.NewCompareFunc[string](), nil)
-	tests[1].expectedEquals = false
 	tests[1].expectedGraphviz = `strict digraph "Red-Black" {
   concentrate=false;
   node [style=filled, shape=oval];
@@ -63,6 +63,11 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 
 	tests[2].symbolTable = "LLRB Tree"
 	tests[2].expectedHeight = 3
+	tests[2].equals = NewRedBlack[string, int](generic.NewCompareFunc[string](), nil)
+	tests[2].equals.Put("D", 4)
+	tests[2].equals.Put("J", 10)
+	tests[2].equals.Put("P", 16)
+	tests[2].expectedEquals = false
 	tests[2].expectedVLRTraverse = []KeyValue[string, int]{{"J", 10}, {"D", 4}, {"A", 1}, {"G", 7}, {"P", 16}, {"M", 13}, {"S", 19}}
 	tests[2].expectedVRLTraverse = []KeyValue[string, int]{{"J", 10}, {"P", 16}, {"S", 19}, {"M", 13}, {"D", 4}, {"G", 7}, {"A", 1}}
 	tests[2].expectedLVRTraverse = []KeyValue[string, int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
@@ -71,11 +76,6 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 	tests[2].expectedRLVTraverse = []KeyValue[string, int]{{"S", 19}, {"M", 13}, {"P", 16}, {"G", 7}, {"A", 1}, {"D", 4}, {"J", 10}}
 	tests[2].expectedAscendingTraverse = []KeyValue[string, int]{{"A", 1}, {"D", 4}, {"G", 7}, {"J", 10}, {"M", 13}, {"P", 16}, {"S", 19}}
 	tests[2].expectedDescendingTraverse = []KeyValue[string, int]{{"S", 19}, {"P", 16}, {"M", 13}, {"J", 10}, {"G", 7}, {"D", 4}, {"A", 1}}
-	tests[2].equals = NewRedBlack[string, int](generic.NewCompareFunc[string](), nil)
-	tests[2].equals.Put("D", 4)
-	tests[2].equals.Put("J", 10)
-	tests[2].equals.Put("P", 16)
-	tests[2].expectedEquals = false
 	tests[2].expectedGraphviz = `strict digraph "Red-Black" {
   concentrate=false;
   node [style=filled, shape=oval];
@@ -98,14 +98,6 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 
 	tests[3].symbolTable = "LLRB Tree"
 	tests[3].expectedHeight = 3
-	tests[3].expectedVLRTraverse = []KeyValue[string, int]{{"box", 2}, {"balloon", 17}, {"baby", 5}, {"band", 11}, {"dance", 13}, {"dad", 3}, {"dome", 7}}
-	tests[3].expectedVRLTraverse = []KeyValue[string, int]{{"box", 2}, {"dance", 13}, {"dome", 7}, {"dad", 3}, {"balloon", 17}, {"band", 11}, {"baby", 5}}
-	tests[3].expectedLVRTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
-	tests[3].expectedRVLTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
-	tests[3].expectedLRVTraverse = []KeyValue[string, int]{{"baby", 5}, {"band", 11}, {"balloon", 17}, {"dad", 3}, {"dome", 7}, {"dance", 13}, {"box", 2}}
-	tests[3].expectedRLVTraverse = []KeyValue[string, int]{{"dome", 7}, {"dad", 3}, {"dance", 13}, {"band", 11}, {"baby", 5}, {"balloon", 17}, {"box", 2}}
-	tests[3].expectedAscendingTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
-	tests[3].expectedDescendingTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
 	tests[3].equals = NewRedBlack[string, int](generic.NewCompareFunc[string](), nil)
 	tests[3].equals.Put("box", 2)
 	tests[3].equals.Put("dad", 3)
@@ -115,6 +107,14 @@ func getRedBlackTests() []orderedSymbolTableTest[string, int] {
 	tests[3].equals.Put("dance", 13)
 	tests[3].equals.Put("balloon", 17)
 	tests[3].expectedEquals = true
+	tests[3].expectedVLRTraverse = []KeyValue[string, int]{{"box", 2}, {"balloon", 17}, {"baby", 5}, {"band", 11}, {"dance", 13}, {"dad", 3}, {"dome", 7}}
+	tests[3].expectedVRLTraverse = []KeyValue[string, int]{{"box", 2}, {"dance", 13}, {"dome", 7}, {"dad", 3}, {"balloon", 17}, {"band", 11}, {"baby", 5}}
+	tests[3].expectedLVRTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
+	tests[3].expectedRVLTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
+	tests[3].expectedLRVTraverse = []KeyValue[string, int]{{"baby", 5}, {"band", 11}, {"balloon", 17}, {"dad", 3}, {"dome", 7}, {"dance", 13}, {"box", 2}}
+	tests[3].expectedRLVTraverse = []KeyValue[string, int]{{"dome", 7}, {"dad", 3}, {"dance", 13}, {"band", 11}, {"baby", 5}, {"balloon", 17}, {"box", 2}}
+	tests[3].expectedAscendingTraverse = []KeyValue[string, int]{{"baby", 5}, {"balloon", 17}, {"band", 11}, {"box", 2}, {"dad", 3}, {"dance", 13}, {"dome", 7}}
+	tests[3].expectedDescendingTraverse = []KeyValue[string, int]{{"dome", 7}, {"dance", 13}, {"dad", 3}, {"box", 2}, {"band", 11}, {"balloon", 17}, {"baby", 5}}
 	tests[3].expectedGraphviz = `strict digraph "Red-Black" {
   concentrate=false;
   node [style=filled, shape=oval];

--- a/symboltable/symbol_table.go
+++ b/symboltable/symbol_table.go
@@ -30,6 +30,9 @@ type (
 	// The VisitFunc type is a function for visiting a key-value pair.
 	VisitFunc[K, V any] func(K, V) bool
 
+	// Predicate is a function for testing a key-value pair.
+	Predicate[K, V any] func(K, V) bool
+
 	// KeyValue represents a key-value pair.
 	KeyValue[K, V any] struct {
 		Key K
@@ -48,6 +51,8 @@ type SymbolTable[K, V any] interface {
 	Delete(K) (V, bool)
 	KeyValues() []KeyValue[K, V]
 	Equals(SymbolTable[K, V]) bool
+	Any(Predicate[K, V]) bool
+	All(Predicate[K, V]) bool
 }
 
 // OrderedSymbolTable represents an ordered symbol table abstract data type.


### PR DESCRIPTION
## Description

  - [x] Add `Any` to symbol table API
  - [x] Add `All` to symbol table API

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
