### PR TITLE
Implement checking isomorphic automata and fix a bug in DFA minimization

### DIFF
--- a/automata/README.md
+++ b/automata/README.md
@@ -1,3 +1,4 @@
+# Automata
 
 Finite automata are recognizers; they simply say yes or no for each possible input string.
 They come in two flavors:

--- a/automata/automata_test.go
+++ b/automata/automata_test.go
@@ -38,54 +38,94 @@ func TestStates_Equals(t *testing.T) {
 	tests := []struct {
 		name           string
 		s              States
-		t              States
-		expectedResult bool
+		rhs            States
+		expectedEquals bool
 	}{
 		{
-			name:           "No",
-			s:              States{2},
-			t:              States{2, 4},
-			expectedResult: false,
+			name:           "Equal",
+			s:              States{2, 4},
+			rhs:            States{4, 2},
+			expectedEquals: true,
 		},
 		{
-			name:           "Yes",
+			name:           "NotEqual",
 			s:              States{2, 4},
-			t:              States{4, 2},
-			expectedResult: true,
+			rhs:            States{2},
+			expectedEquals: false,
+		},
+		{
+			name:           "NotEqual",
+			s:              States{2},
+			rhs:            States{2, 4},
+			expectedEquals: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedResult, tc.s.Equals(tc.t))
+			assert.Equal(t, tc.expectedEquals, tc.s.Equals(tc.rhs))
 		})
 	}
 }
 
 func TestSymbols_Contains(t *testing.T) {
 	tests := []struct {
-		name           string
-		s              Symbols
-		t              Symbol
-		expectedResult bool
+		name             string
+		s                Symbols
+		t                Symbol
+		expectedContains bool
 	}{
 		{
-			name:           "No",
-			s:              Symbols{'b', 'd'},
-			t:              'c',
-			expectedResult: false,
+			name:             "Yes",
+			s:                Symbols{'a', 'b'},
+			t:                'b',
+			expectedContains: true,
 		},
 		{
-			name:           "Yes",
-			s:              Symbols{'b', 'd'},
-			t:              'd',
-			expectedResult: true,
+			name:             "No",
+			s:                Symbols{'a', 'b'},
+			t:                'c',
+			expectedContains: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedResult, tc.s.Contains(tc.t))
+			assert.Equal(t, tc.expectedContains, tc.s.Contains(tc.t))
+		})
+	}
+}
+
+func TestSymbols_Equals(t *testing.T) {
+	tests := []struct {
+		name           string
+		s              Symbols
+		rhs            Symbols
+		expectedEquals bool
+	}{
+		{
+			name:           "Equal",
+			s:              Symbols{'a', 'b'},
+			rhs:            Symbols{'b', 'a'},
+			expectedEquals: true,
+		},
+		{
+			name:           "NotEqual",
+			s:              Symbols{'a', 'b'},
+			rhs:            Symbols{'a'},
+			expectedEquals: false,
+		},
+		{
+			name:           "NotEqual",
+			s:              Symbols{'a'},
+			rhs:            Symbols{'a', 'b'},
+			expectedEquals: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedEquals, tc.s.Equals(tc.rhs))
 		})
 	}
 }
@@ -106,6 +146,41 @@ func TestToString(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expectedString, ToString(tc.s))
+		})
+	}
+}
+
+func TestGeneratePermutations(t *testing.T) {
+	tests := []struct {
+		name                 string
+		states               States
+		start                int
+		end                  int
+		expectedReturn       bool
+		expectedPermutations []States
+	}{
+		{
+			name:   "OK",
+			states: States{0, 1, 2},
+			start:  0,
+			end:    2,
+			expectedPermutations: []States{
+				{0, 1, 2},
+				{0, 2, 1},
+				{1, 0, 2},
+				{1, 2, 0},
+				{2, 1, 0},
+				{2, 0, 1},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, generatePermutations(tc.states, tc.start, tc.end, func(perm States) bool {
+				assert.Contains(t, tc.expectedPermutations, perm)
+				return true
+			}))
 		})
 	}
 }

--- a/automata/dfa_test.go
+++ b/automata/dfa_test.go
@@ -282,7 +282,7 @@ func TestDFA_Minimize(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			dfa := tc.d.Minimize()
-			assert.True(t, dfa.Equals(tc.expectedDFA))
+			assert.True(t, dfa.Isomorphic(tc.expectedDFA))
 		})
 	}
 }
@@ -316,26 +316,112 @@ func TestDFA_Equals(t *testing.T) {
 	tests := []struct {
 		name           string
 		d              *DFA
-		dfa            *DFA
+		rhs            *DFA
 		expectedEquals bool
 	}{
 		{
 			name:           "Equal",
 			d:              dfas[0],
-			dfa:            dfas[0],
+			rhs:            dfas[0],
 			expectedEquals: true,
 		},
 		{
 			name:           "NotEqual",
 			d:              dfas[0],
-			dfa:            dfas[1],
+			rhs:            dfas[1],
 			expectedEquals: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedEquals, tc.d.Equals(tc.dfa))
+			assert.Equal(t, tc.expectedEquals, tc.d.Equals(tc.rhs))
+		})
+	}
+}
+
+func TestDFA_Isomorphic(t *testing.T) {
+	// aa*|bb*
+	d0 := NewDFA(0, States{1, 2})
+	d0.Add(0, 'a', 1)
+	d0.Add(1, 'a', 1)
+	d0.Add(0, 'b', 2)
+	d0.Add(2, 'b', 2)
+
+	d1 := NewDFA(0, States{1})
+
+	d2 := NewDFA(0, States{2, 4})
+	d2.Add(0, 'a', 1)
+	d2.Add(1, 'a', 2)
+	d2.Add(2, 'a', 2)
+	d2.Add(0, 'b', 3)
+	d2.Add(3, 'b', 4)
+	d2.Add(4, 'b', 4)
+
+	d3 := NewDFA(0, States{1, 2})
+	d3.Add(0, 'a', 1)
+	d3.Add(1, 'c', 1)
+	d3.Add(0, 'b', 2)
+	d3.Add(2, 'c', 2)
+
+	d4 := NewDFA(0, States{1, 2})
+	d4.Add(0, 'a', 1)
+	d4.Add(1, 'a', 1)
+	d4.Add(0, 'b', 2)
+
+	d5 := NewDFA(2, States{0, 1})
+	d5.Add(2, 'a', 0)
+	d5.Add(0, 'a', 0)
+	d5.Add(2, 'b', 1)
+	d5.Add(1, 'b', 1)
+
+	tests := []struct {
+		name               string
+		d                  *DFA
+		rhs                *DFA
+		expectedIsomorphic bool
+	}{
+		{
+			name:               "FinalStatesNotEqualSize",
+			d:                  d0,
+			rhs:                d1,
+			expectedIsomorphic: false,
+		},
+		{
+			name:               "StatesNotEqualSize",
+			d:                  d0,
+			rhs:                d2,
+			expectedIsomorphic: false,
+		},
+		{
+			name:               "SymbolsNotEqual",
+			d:                  d0,
+			rhs:                d3,
+			expectedIsomorphic: false,
+		},
+		{
+			name:               "DegreesNotEqual",
+			d:                  d0,
+			rhs:                d4,
+			expectedIsomorphic: false,
+		},
+		{
+			name:               "Equal",
+			d:                  d0,
+			rhs:                d0,
+			expectedIsomorphic: true,
+		},
+		{
+			name:               "Isomorphic",
+			d:                  d0,
+			rhs:                d5,
+			expectedIsomorphic: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedIsomorphic, tc.d.Isomorphic(tc.rhs))
 		})
 	}
 }

--- a/automata/nfa_test.go
+++ b/automata/nfa_test.go
@@ -358,26 +358,117 @@ func TestNFA_Equals(t *testing.T) {
 	tests := []struct {
 		name           string
 		n              *NFA
-		nfa            *NFA
+		rhs            *NFA
 		expectedEquals bool
 	}{
 		{
 			name:           "Equal",
 			n:              nfas[0],
-			nfa:            nfas[0],
+			rhs:            nfas[0],
 			expectedEquals: true,
 		},
 		{
 			name:           "NotEqual",
 			n:              nfas[0],
-			nfa:            nfas[1],
+			rhs:            nfas[1],
 			expectedEquals: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedEquals, tc.n.Equals(tc.nfa))
+			assert.Equal(t, tc.expectedEquals, tc.n.Equals(tc.rhs))
+		})
+	}
+}
+
+func TestNFA_Isomorphic(t *testing.T) {
+	// aa*|bb*
+	n0 := NewNFA(0, States{2, 4})
+	n0.Add(0, E, States{1, 3})
+	n0.Add(1, 'a', States{2})
+	n0.Add(2, 'a', States{2})
+	n0.Add(3, 'b', States{4})
+	n0.Add(4, 'b', States{4})
+
+	n1 := NewNFA(0, States{2})
+
+	n2 := NewNFA(0, States{3, 6})
+	n2.Add(0, E, States{1, 4})
+	n2.Add(1, 'a', States{2})
+	n2.Add(2, 'a', States{3})
+	n2.Add(3, 'a', States{3})
+	n2.Add(4, 'b', States{5})
+	n2.Add(5, 'b', States{6})
+	n2.Add(6, 'b', States{6})
+
+	n3 := NewNFA(0, States{2, 4})
+	n3.Add(0, E, States{1, 3})
+	n3.Add(1, 'a', States{2})
+	n3.Add(2, 'c', States{2})
+	n3.Add(3, 'b', States{4})
+	n3.Add(4, 'c', States{4})
+
+	n4 := NewNFA(0, States{2, 4})
+	n4.Add(0, E, States{1, 3})
+	n4.Add(1, 'a', States{2})
+	n4.Add(2, 'a', States{2})
+	n4.Add(3, 'b', States{4})
+
+	n5 := NewNFA(4, States{0, 1})
+	n5.Add(4, E, States{2, 3})
+	n5.Add(2, 'a', States{0})
+	n5.Add(0, 'a', States{0})
+	n5.Add(3, 'b', States{1})
+	n5.Add(1, 'b', States{1})
+
+	tests := []struct {
+		name               string
+		n                  *NFA
+		rhs                *NFA
+		expectedIsomorphic bool
+	}{
+		{
+			name:               "FinalStatesNotEqualSize",
+			n:                  n0,
+			rhs:                n1,
+			expectedIsomorphic: false,
+		},
+		{
+			name:               "StatesNotEqualSize",
+			n:                  n0,
+			rhs:                n2,
+			expectedIsomorphic: false,
+		},
+		{
+			name:               "SymbolsNotEqual",
+			n:                  n0,
+			rhs:                n3,
+			expectedIsomorphic: false,
+		},
+		{
+			name:               "DegreesNotEqual",
+			n:                  n0,
+			rhs:                n4,
+			expectedIsomorphic: false,
+		},
+		{
+			name:               "Equal",
+			n:                  n0,
+			rhs:                n0,
+			expectedIsomorphic: true,
+		},
+		{
+			name:               "Isomorphic",
+			n:                  n0,
+			rhs:                n5,
+			expectedIsomorphic: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedIsomorphic, tc.n.Isomorphic(tc.rhs))
 		})
 	}
 }

--- a/automata/partition.go
+++ b/automata/partition.go
@@ -1,0 +1,149 @@
+package automata
+
+import (
+	. "github.com/moorara/algo/generic"
+	"github.com/moorara/algo/symboltable"
+)
+
+// group represents a subset of states within a partition.
+// Each group is uniquely identified by a representative state.
+type group struct {
+	rep    State
+	states States
+}
+
+// Equals determines whether or not two partition groups are equal.
+func (g group) Equals(rhs group) bool {
+	return g.states.Equals(rhs.states)
+}
+
+// groups represents a list of partition groups.
+type groups []group
+
+// Contains determines whether or not a list of partition groups contains a given group.
+func (g groups) Contains(h group) bool {
+	for _, group := range g {
+		if group.Equals(h) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Equals determines whether or not two lists of partition groups are equal.
+func (g groups) Equals(rhs groups) bool {
+	for _, group := range g {
+		if !rhs.Contains(group) {
+			return false
+		}
+	}
+
+	for _, group := range rhs {
+		if !g.Contains(group) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// partition represents a partition of the states in an automaton.
+// Each partition divides the states into disjoint groups.
+type partition struct {
+	groups
+	nextRep State
+}
+
+// newPartition creates a new partition set.
+func newPartition() *partition {
+	return &partition{
+		groups:  groups{},
+		nextRep: 0,
+	}
+}
+
+// Equals determines whether or not two partitions are equal.
+func (p *partition) Equals(rhs *partition) bool {
+	return p.groups.Equals(rhs.groups)
+}
+
+// Add adds new groups into the partition set.
+// Each group is a set of states and assigned a unique representative state.
+func (p *partition) Add(groups ...States) {
+	for _, groupStates := range groups {
+		p.groups = append(p.groups, group{
+			rep:    p.nextRep,
+			states: groupStates,
+		})
+
+		p.nextRep++
+	}
+}
+
+// Rep finds the group containing the given state and returns its representative state.
+// If the state is not found in any group, it returns -1 and false.
+func (p *partition) Rep(s State) (State, bool) {
+	for _, G := range p.groups {
+		if G.states.Contains(s) {
+			return G.rep, true
+		}
+	}
+
+	return -1, false
+}
+
+// BuildGroupTrans creates a map of state-symbol pairs to the group representatives in the current partition.
+// Instead of mapping to next states, the map associates each symbol with the representative of the group containing the next state.
+func (p *partition) BuildGroupTrans(dfa *DFA, G group) doubleKeyMap[State, Symbol, State] {
+	Gtrans := symboltable.NewRedBlack[State, symboltable.SymbolTable[Symbol, State]](cmpState, eqSymbolState)
+
+	// For every state in the current group
+	for _, s := range G.states {
+		strans := symboltable.NewRedBlack[Symbol, State](cmpSymbol, eqState)
+
+		// Create a map of symbols to the current partition's group representatives (instead of next states)
+		if v, ok := dfa.trans.Get(s); ok {
+			for a, next := range v.All() {
+				if rep, ok := p.Rep(next); ok {
+					strans.Put(a, rep)
+				}
+			}
+		}
+
+		Gtrans.Put(s, strans)
+	}
+
+	return Gtrans
+}
+
+// PartitionAndAddGroups partitions each group into subgroups and adds them to the partition set.
+//
+// This method partitions the group G into subgroups such that two states s and t are in the same subgroup
+// if and only if, for all input symbols a, the transitions of s and t on a lead to states in the same group.
+// If no such grouping is possible, a state will be placed in a subgroup by itself.
+func (p *partition) PartitionAndAddGroups(Gtrans doubleKeyMap[State, Symbol, State]) {
+	pairs := Collect(Gtrans.All())
+
+	for i := 0; i < len(pairs); i++ {
+		s, strans := pairs[i].Key, pairs[i].Val
+
+		// If s is not already added to the new partition
+		if _, ok := p.Rep(s); !ok {
+			// Create a new group in the new partition
+			H := States{}
+			H = append(H, s)
+
+			// Add all other state with same symbol->rep map to the new group
+			for j := 1; j < len(pairs); j++ {
+				t, ttrans := pairs[j].Key, pairs[j].Val
+
+				if strans.Equals(ttrans) && !H.Contains(t) {
+					H = append(H, t)
+				}
+			}
+
+			p.Add(H)
+		}
+	}
+}

--- a/automata/partition_test.go
+++ b/automata/partition_test.go
@@ -1,0 +1,360 @@
+package automata
+
+import (
+	"testing"
+
+	"github.com/moorara/algo/symboltable"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroup_Equals(t *testing.T) {
+	tests := []struct {
+		name           string
+		g              group
+		rhs            group
+		expectedEquals bool
+	}{
+		{
+			name:           "Equal",
+			g:              group{rep: 0, states: States{0, 1, 2}},
+			rhs:            group{rep: 1, states: States{0, 1, 2}},
+			expectedEquals: true,
+		},
+		{
+			name:           "NotEqual",
+			g:              group{rep: 0, states: States{0, 1, 2}},
+			rhs:            group{rep: 1, states: States{0, 1, 2, 3}},
+			expectedEquals: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedEquals, tc.g.Equals(tc.rhs))
+		})
+	}
+}
+
+func TestGroups_Contains(t *testing.T) {
+	tests := []struct {
+		name             string
+		g                groups
+		h                group
+		expectedContains bool
+	}{
+		{
+			name: "Yes",
+			g: groups{
+				group{rep: 0, states: States{0}},
+				group{rep: 1, states: States{1, 2}},
+				group{rep: 2, states: States{3, 4}},
+			},
+			h:                group{rep: 1, states: States{1, 2}},
+			expectedContains: true,
+		},
+		{
+			name: "No",
+			g: groups{
+				group{rep: 0, states: States{0}},
+				group{rep: 1, states: States{1, 2}},
+				group{rep: 2, states: States{3, 4}},
+			},
+			h:                group{rep: 1, states: States{2, 4}},
+			expectedContains: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedContains, tc.g.Contains(tc.h))
+		})
+	}
+}
+
+func TestGroups_Equals(t *testing.T) {
+	tests := []struct {
+		name           string
+		g              groups
+		rhs            groups
+		expectedEquals bool
+	}{
+		{
+			name: "Equal",
+			g: groups{
+				group{rep: 0, states: States{0}},
+				group{rep: 1, states: States{1, 2}},
+				group{rep: 2, states: States{3, 4}},
+			},
+			rhs: groups{
+				group{rep: 0, states: States{0}},
+				group{rep: 1, states: States{1, 2}},
+				group{rep: 2, states: States{3, 4}},
+			},
+			expectedEquals: true,
+		},
+		{
+			name: "NotEqual",
+			g: groups{
+				group{rep: 0, states: States{0}},
+				group{rep: 1, states: States{1, 2}},
+				group{rep: 2, states: States{3, 4}},
+			},
+			rhs: groups{
+				group{rep: 0, states: States{0}},
+				group{rep: 1, states: States{1, 2}},
+				group{rep: 2, states: States{3}},
+				group{rep: 3, states: States{4}},
+			},
+			expectedEquals: false,
+		},
+		{
+			name: "NotEqual",
+			g: groups{
+				group{rep: 0, states: States{0}},
+				group{rep: 1, states: States{1, 2}},
+				group{rep: 2, states: States{3, 4}},
+			},
+			rhs: groups{
+				group{rep: 0, states: States{0}},
+				group{rep: 1, states: States{1, 2}},
+				group{rep: 2, states: States{3, 4}},
+				group{rep: 3, states: States{5, 6}},
+			},
+			expectedEquals: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedEquals, tc.g.Equals(tc.rhs))
+		})
+	}
+}
+
+func TestNewPartition(t *testing.T) {
+	p := newPartition()
+	assert.NotNil(t, p)
+}
+
+func TestPartition_Equals(t *testing.T) {
+	tests := []struct {
+		name           string
+		p              *partition
+		rhs            *partition
+		expectedEquals bool
+	}{
+		{
+			name: "Equal",
+			p: &partition{
+				groups: groups{
+					group{rep: 0, states: States{0}},
+					group{rep: 1, states: States{1, 2}},
+				},
+				nextRep: 2,
+			},
+			rhs: &partition{
+				groups: groups{
+					group{rep: 0, states: States{0}},
+					group{rep: 1, states: States{1, 2}},
+				},
+				nextRep: 2,
+			},
+			expectedEquals: true,
+		},
+		{
+			name: "NotEqual",
+			p: &partition{
+				groups: groups{
+					group{rep: 0, states: States{0}},
+					group{rep: 1, states: States{1, 2}},
+				},
+				nextRep: 2,
+			},
+			rhs: &partition{
+				groups: groups{
+					group{rep: 0, states: States{0}},
+					group{rep: 1, states: States{1}},
+					group{rep: 2, states: States{2}},
+				},
+				nextRep: 3,
+			},
+			expectedEquals: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedEquals, tc.p.Equals(tc.rhs))
+		})
+	}
+}
+
+func TestPartition_Add(t *testing.T) {
+	tests := []struct {
+		name              string
+		p                 *partition
+		groups            []States
+		expectedPartition *partition
+	}{
+		{
+			name: "OK",
+			p: &partition{
+				groups: groups{
+					group{rep: 0, states: States{0}},
+				},
+				nextRep: 1,
+			},
+			groups: []States{
+				{1, 2},
+				{3, 4},
+			},
+			expectedPartition: &partition{
+				groups: groups{
+					group{rep: 0, states: States{0}},
+					group{rep: 1, states: States{1, 2}},
+					group{rep: 2, states: States{3, 4}},
+				},
+				nextRep: 4,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.p.Add(tc.groups...)
+			assert.True(t, tc.p.Equals(tc.expectedPartition))
+		})
+	}
+}
+
+func TestPartition_Rep(t *testing.T) {
+	tests := []struct {
+		name        string
+		p           *partition
+		s           State
+		expectedOK  bool
+		expectedRep State
+	}{
+		{
+			name: "OK",
+			p: &partition{
+				groups: groups{
+					group{rep: 0, states: States{0}},
+					group{rep: 1, states: States{1, 2}},
+					group{rep: 2, states: States{3, 4}},
+				},
+				nextRep: 4,
+			},
+			s:           State(4),
+			expectedOK:  true,
+			expectedRep: State(2),
+		},
+		{
+			name: "NotOK",
+			p: &partition{
+				groups: groups{
+					group{rep: 0, states: States{0}},
+					group{rep: 1, states: States{1, 2}},
+					group{rep: 2, states: States{3, 4}},
+				},
+				nextRep: 4,
+			},
+			s:           State(8),
+			expectedOK:  false,
+			expectedRep: -1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rep, ok := tc.p.Rep(tc.s)
+			assert.Equal(t, tc.expectedOK, ok)
+			assert.Equal(t, tc.expectedRep, rep)
+		})
+	}
+}
+
+func TestPartition_BuildGroupTrans(t *testing.T) {
+	dfa := getTestDFAs()[2]
+
+	trans := symboltable.NewRedBlack(cmpState, eqSymbolState)
+
+	s2Trans := symboltable.NewRedBlack(cmpSymbol, eqState)
+	s2Trans.Put('b', 1)
+	trans.Put(2, s2Trans)
+
+	s4Trans := symboltable.NewRedBlack(cmpSymbol, eqState)
+	s4Trans.Put('a', 1)
+	trans.Put(4, s4Trans)
+
+	tests := []struct {
+		name          string
+		p             *partition
+		dfa           *DFA
+		G             group
+		expectedTrans doubleKeyMap[State, Symbol, State]
+	}{
+		{
+			name: "OK",
+			p: &partition{
+				groups: groups{
+					group{rep: 0, states: States{0, 1, 3}},
+					group{rep: 1, states: States{2, 4}},
+				},
+				nextRep: 2,
+			},
+			dfa:           dfa,
+			G:             group{rep: 1, states: States{2, 4}},
+			expectedTrans: trans,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			trans := tc.p.BuildGroupTrans(tc.dfa, tc.G)
+			assert.True(t, trans.Equals(tc.expectedTrans))
+		})
+	}
+}
+
+func TestPartition_PartitionAndAddGroups(t *testing.T) {
+	trans := symboltable.NewRedBlack(cmpState, eqSymbolState)
+
+	s2Trans := symboltable.NewRedBlack(cmpSymbol, eqState)
+	s2Trans.Put('b', 1)
+	trans.Put(2, s2Trans)
+
+	s4Trans := symboltable.NewRedBlack(cmpSymbol, eqState)
+	s4Trans.Put('a', 1)
+	trans.Put(4, s4Trans)
+
+	tests := []struct {
+		name              string
+		p                 *partition
+		Gtrans            doubleKeyMap[State, Symbol, State]
+		expectedPartition *partition
+	}{
+		{
+			name: "OK",
+			p: &partition{
+				groups:  groups{},
+				nextRep: 0,
+			},
+			Gtrans: trans,
+			expectedPartition: &partition{
+				groups: groups{
+					group{rep: 0, states: States{2}},
+					group{rep: 1, states: States{4}},
+				},
+				nextRep: 2,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.p.PartitionAndAddGroups(tc.Gtrans)
+			assert.True(t, tc.p.Equals(tc.expectedPartition))
+		})
+	}
+}


### PR DESCRIPTION
## Description

  - [x] Add the `Isomorphic` method to `DFA` and `NFA` to check if two automata are structurally identical.
  - [x] Fix a bug in DFA minimization.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
