### PR TITLE
Add binomial heap as an implementation of a mergeable heap

### DIFF
--- a/heap/binary_test.go
+++ b/heap/binary_test.go
@@ -134,7 +134,7 @@ func TestBinaryHeap(t *testing.T) {
 	tests := getBinaryTests()
 
 	for _, tc := range tests {
-		heap := NewBinary[int, string](tc.size, tc.cmpKey, tc.eqVal)
+		heap := NewBinary(tc.size, tc.cmpKey, tc.eqVal)
 		runHeapTest(t, heap, tc)
 	}
 }

--- a/heap/binomial.go
+++ b/heap/binomial.go
@@ -1,0 +1,447 @@
+package heap
+
+import (
+	"fmt"
+
+	. "github.com/moorara/algo/generic"
+	"github.com/moorara/algo/internal/graphviz"
+)
+
+// The Left-Child-Right-Sibling (LCRS) representation, a.k.a. the Binary Representation of N-ary Tree,
+// is used for implementing the binomial tree.
+//
+//   - The left child of a node points to its first child.
+//   - The right sibling of a node points to its next sibling.
+//
+// A binomial heap consists of a list of root nodes (root list) of binomial trees
+// sorted by the increasing order of binomial trees.
+//
+//   - Each root node represents the root of a binomial tree in the heap.
+//   - The root nodes of binomial trees are linked together using the right sibling pointers.
+//   - The children of each node, including root nodes, are linked using the left child and right sibling pointers.
+//
+// Examples of binomial heaps in LCRS representation:
+//
+//	[ 9 ]──────[ 1 ]──────────[ 3 ]                    [ 9 ]----[ 1 ]----[ 3 ]
+//	             │         ┌────┴────┐                            │        │
+//	           [ 10 ]    [ 5 ]     [ 4 ]       --->             [ 10 ]   [ 5 ]----[ 4 ]
+//	                       │                                               │
+//	                     [ 12 ]                                          [ 12 ]
+//
+//	[ 4 ]────────────────[ 2 ]                         [ 4 ]----[ 2 ]
+//	         ┌─────────────┼─────────────┐                        │
+//	       [ 3 ]         [ 5 ]        [ 8 ]                     [ 3 ]-------------[ 5 ]----[ 8 ]
+//	    ┌────┴────┐        │                   --->               │                 │
+//	  [ 6 ]      [ 12 ]  [ 11 ]                                 [ 6 ]----[ 12 ]   [ 11 ]
+//	    │                                                         │
+//	  [ 14 ]                                                    [ 14 ]
+//
+// The LCRS representation uses two pointers per node regardless of the number of children.
+type binomialNode[K, V any] struct {
+	key            K
+	val            V
+	order          int // order of the binomial tree rooted at this node
+	child, sibling *binomialNode[K, V]
+}
+
+// binomial implements a binomial heap.
+// A binomial heap is implemented as a list of root nodes (root list) of binomial trees
+// sorted by the increasing order of binomial trees.
+type binomial[K, V any] struct {
+	cmpKey CompareFunc[K]
+	eqVal  EqualFunc[V]
+
+	n    int                 // number of items on heap
+	head *binomialNode[K, V] // head of the root list
+}
+
+// NewBinomial creates a new binomial heap that can be used as a priority queue.
+//
+// Binomial heap is an implementation of the mergeable heap ADT, a priority queue supporting merge operation.
+// A binomial heap is implemented as a set of binomial trees that satisfy the binomial heap properties:
+//
+//   - Heap Property: Every binomial tree in a binomial heap satisfies the min-heap or max-heap property.
+//   - Structural Property: The heap contains at most one binomial tree of any given order.
+//
+// A binomial tree Bₖ of order k is defined recursively:
+//
+//   - A binomial tree B₀ of order 0 is a single node.
+//   - A binomial tree Bₖ of order k is formed by linking two binomial trees of orders k-1 together,
+//     making the root of one tree a child of the root of the other tree.
+//     Equivalently, a binomial tree Bₖ has a root node whose children are roots of binomial trees of orders k-1, k-2, ..., 1, 0.
+//
+// The number inside each node denotes the order of the binomial sub-tree rooted at that node.
+//
+//	[ 0 ]    [ 1 ]          [ 2 ]                          [ 3 ]
+//	           │         ┌────┴────┐             ┌───────────┼───────────┐
+//	         [ 0 ]    [ 1 ]      [ 0 ]         [ 2 ]       [ 1 ]       [ 0 ]
+//	                    │                   ┌────┴────┐      │
+//	                  [ 0 ]               [ 1 ]     [ 0 ]  [ 0 ]
+//	                                        │
+//	                                      [ 0 ]
+//
+// Examples of minimum binomial heaps:
+//
+//	[ 9 ]────[ 1 ]────────[ 3 ]
+//	           │       ┌────┴────┐
+//	         [ 10 ]  [ 5 ]     [ 4 ]
+//	                   │
+//	                 [ 12 ]
+//
+//	[ 4 ]───────────────────[ 2 ]
+//	             ┌────────────┼────────────┐
+//	           [ 3 ]        [ 5 ]        [ 8 ]
+//	        ┌────┴────┐       │
+//	      [ 6 ]     [ 12 ]  [ 11 ]
+//	        │
+//	      [ 14 ]
+//
+// Here are some properties of binomial trees:
+//
+//   - The height of a Bₖ tree is k.
+//   - The number of nodes in a Bₖ tree is 2ᵏ.
+//   - The root of a Bₖ tree has k children.
+//   - The children of the root of a Bₖ tree are the roots of B₀, B₁, ..., Bₖ₋₁ trees.
+//   - A binomial tree Bₖ of order k has C(k, d) nodes at depth d, a binomial coefficient.
+//
+// cmpKey is a function for comparing two keys.
+// eqVal is a function for checking the equality of two values.
+func NewBinomial[K, V any](cmpKey CompareFunc[K], eqVal EqualFunc[V]) MergeableHeap[K, V] {
+	return &binomial[K, V]{
+		cmpKey: cmpKey,
+		eqVal:  eqVal,
+		n:      0,
+		head:   nil,
+	}
+}
+
+// mergeBinomialTrees constructs a binomial tree of order k+1 from two binomial trees of order k.
+// It attaches one of the root nodes as the left-most child of the other.
+//
+// It accepts two root nodes and assumes the key of the first root comes after
+// the key of the second root (greater in min heap or smaller in max heap).
+// The second root then becomes the new root.
+//
+// General tree representation:
+//
+//	     [ 3 ]                   [ 2 ]                                  [ 2 ]
+//	  ┌────┴────┐             ┌────┴────┐                     ┌───────────┼───────────┐
+//	[ 7 ]     [ 5 ]    +    [ 6 ]     [ 4 ]    --->         [ 3 ]       [ 6 ]       [ 4 ]
+//	  │                       │                          ┌────┴────┐      │
+//	[ 9 ]                   [ 8 ]                      [ 7 ]     [ 5 ]  [ 8 ]
+//	                                                     │
+//	                                                   [ 8 ]
+//
+// LCRS representation:
+//
+//	[ 3 ]                  [ 2 ]                     [ 2 ]
+//	  │                      │                         │
+//	[ 7 ]----[ 5 ]    +    [ 6 ]----[ 4 ]    --->    [ 3 ]-----------[ 6 ]----[ 4 ]
+//	  │                      │                         │               │
+//	[ 9 ]                  [ 8 ]                     [ 7 ]----[ 5 ]  [ 8 ]
+//	                                                   │
+//	                                                 [ 8 ]
+func mergeBinomialTrees[K, V any](child, parent *binomialNode[K, V]) {
+	child.sibling = parent.child
+	parent.child = child
+	parent.order++
+}
+
+// merge performs a merge sort on two root lists of binomial trees.
+//
+// The resulting root list is sorted in monotonically increasing order of binomial tree orders,
+// and it may contain up to two binomial trees of the same order.
+// These trees are combined later during the consolidate operation, which follows this merge operation.
+//
+// Below are examples illustrating all possible cases when merging two root lists.
+// The number inside each node denotes the order of the binomial tree rooted at that node.
+//
+// Case 1: x = nil, y = nil
+//
+//	nil    +    nil    =    nil
+//
+// Case 2: x = nil, y ≠ nil
+//
+//	nil    +    [ 0 ]----[ 1 ]    =    [ 0 ]----[ 1 ]
+//	                       │                      │
+//	                     [ 0 ]                  [ 0 ]
+//
+// Case 3: x ≠ nil, y = nil
+//
+//	[ 0 ]----[ 1 ]    +    nil    =    [ 0 ]----[ 1 ]
+//	           │                                  │
+//	         [ 0 ]                              [ 0 ]
+//
+// Case 4: x.order < y.order
+//
+//	[ 0 ]----[ 2 ]                  [ 1 ]----[ 3 ]                                  [ 0 ]----[ 1 ]----[ 2 ]-------------[ 3 ]
+//	           │                      │        │                                               │        │                 │
+//	         [ 1 ]----[ 0 ]    +    [ 0 ]    [ 2 ]-----------[ 1 ]----[ 0 ]    =             [ 0 ]    [ 1 ]----[ 0 ]    [ 2 ]-----------[ 1 ]----[ 0 ]
+//	           │                               │               │                                        │                 │               │
+//	         [ 0 ]                           [ 1 ]----[ 0 ]  [ 0 ]                                    [ 0 ]             [ 1 ]----[ 0 ]  [ 0 ]
+//	                                           │                                                                          │
+//	                                         [ 0 ]                                                                      [ 0 ]
+//
+// Case 5: x.order ≥ y.order
+//
+//	[ 1 ]----[ 3 ]                                  [ 0 ]----[ 2 ]                  [ 0 ]----[ 1 ]----[ 2 ]-------------[ 3 ]
+//	  │        │                                               │                               │        │                 │
+//	[ 0 ]    [ 2 ]-----------[ 1 ]----[ 0 ]    +             [ 1 ]----[ 0 ]    +             [ 0 ]    [ 1 ]----[ 0 ]    [ 2 ]-----------[ 1 ]----[ 0 ]
+//	           │               │                               │                                        │                 │               │
+//	         [ 1 ]----[ 0 ]  [ 0 ]                           [ 0 ]                                    [ 0 ]             [ 1 ]----[ 0 ]  [ 0 ]
+//	           │                                                                                                          │
+//	         [ 0 ]                                                                                                      [ 0 ]
+func mergeRootLists[K, V any](x, y *binomialNode[K, V]) *binomialNode[K, V] {
+	switch {
+	case x == nil:
+		return y
+	case y == nil:
+		return x
+	case x.order < y.order:
+		x.sibling = mergeRootLists(x.sibling, y)
+		return x
+	default:
+		y.sibling = mergeRootLists(x, y.sibling)
+		return y
+	}
+}
+
+// consolidateRootList consolidates the root list of a binomial heap by
+// iterating through the root list and merging binomial trees of the same order.
+// It ensures after consolidation, no two binomial trees in the root list have the same order.
+func consolidateRootList[K, V any](head *binomialNode[K, V], cmpKey CompareFunc[K]) *binomialNode[K, V] {
+	if head == nil {
+		return nil
+	}
+
+	// Scanning the root list of binomial trees.
+	var prev, curr, next *binomialNode[K, V]
+	for prev, curr, next = nil, head, head.sibling; next != nil; next = curr.sibling {
+		if curr.order != next.order || (next.sibling != nil && next.sibling.order == curr.order) {
+			/*
+			 * Case 1: The current and the next binomal trees have different orders.
+			 *         There is no conflict in this case and we proceed with scanning.
+			 *
+			 * Case 2: The current and the next binomal trees have the same order,
+			 *         but the next has a sibling with the same order as the current.
+			 *
+			 *         This case can occur when there are two binmal trees of order k-1
+			 *           followed by two binomia tress of order k in the root list.
+			 *         After merging the two binomial trees of order k-1,
+			 *           we end up with three binomial trees of order k.
+			 *         If we merge the first two binomial trees of order k immediately,
+			 *           it would result in a binomail tree of order k+1 positioned before a binomial tree of order k.
+			 *         This violates the structural properties of the binomial heap.
+			 *         Instead, we defer merging of the two binomial trees of order k to avoid creating additional conflicts.
+			 */
+			prev, curr = curr, next
+		} else if cmpKey(next.key, curr.key) > 0 {
+			// Case 3: The next binomial tree should become the child of current one.
+			curr.sibling = next.sibling
+			mergeBinomialTrees(next, curr)
+		} else {
+			// Case 4: The current binomial tree should become the child of next one.
+			if prev == nil {
+				head = next
+			} else {
+				prev.sibling = next
+			}
+			mergeBinomialTrees(curr, next)
+			curr = next
+		}
+	}
+
+	return head
+}
+
+// union merges two binomial heaps into a single binomial heap.
+func union[K, V any](h1, h2 *binomialNode[K, V], cmpKey CompareFunc[K]) *binomialNode[K, V] {
+	head := mergeRootLists(h1, h2)
+	head = consolidateRootList(head, cmpKey)
+	return head
+}
+
+// Size returns the number of items on the heap.
+func (h *binomial[K, V]) Size() int {
+	return h.n
+}
+
+// IsEmpty returns true if the heap is empty.
+func (h *binomial[K, V]) IsEmpty() bool {
+	return h.head == nil
+}
+
+// Insert adds a new key-value pair to the heap.
+func (h *binomial[K, V]) Insert(key K, val V) {
+	n := &binomialNode[K, V]{
+		key:   key,
+		val:   val,
+		order: 0,
+	}
+
+	h.head = union(h.head, n, h.cmpKey)
+	h.n++
+}
+
+// Merge merges the current heap with another heap.
+// The new heap must have the same underlying type as the current one.
+func (h *binomial[K, V]) Merge(H MergeableHeap[K, V]) {
+	if v, ok := H.(*binomial[K, V]); ok {
+		h.head = union(h.head, v.head, h.cmpKey)
+		h.n += v.n
+	}
+}
+
+// Delete removes the extremum (minimum or maximum) key with its value on the heap.
+// If the heap is empty, the second return value will be false.
+func (h *binomial[K, V]) Delete() (K, V, bool) {
+	if h.IsEmpty() {
+		var zeroK K
+		var zeroV V
+		return zeroK, zeroV, false
+	}
+
+	// Find the extermum (minimum in min heap or maximum in max heap) root.
+	var prev, ext, curr *binomialNode[K, V]
+	for prev, ext, curr = nil, h.head, h.head; curr.sibling != nil; curr = curr.sibling {
+		if h.cmpKey(curr.sibling.key, ext.key) < 0 {
+			prev, ext = curr, curr.sibling
+		}
+	}
+
+	// Remove the extermum node from the root list.
+	if prev == nil { // ext == h.head
+		h.head = ext.sibling
+	} else {
+		prev.sibling = ext.sibling
+	}
+
+	// Reverse the order of the extermum node's children making a new root list.
+	var next *binomialNode[K, V]
+	for prev, curr = nil, ext.child; curr != nil; prev, curr = curr, next {
+		next = curr.sibling
+		curr.sibling = prev
+	}
+
+	// prev is now the head of the new root list.
+	h.head = union(h.head, prev, h.cmpKey)
+	h.n--
+
+	return ext.key, ext.val, true
+}
+
+// DeleteAll deletes all keys with their values on the heap, leaving it empty.
+func (h *binomial[K, V]) DeleteAll() {
+	h.n = 0
+	h.head = nil
+}
+
+// Peek returns the extremum (minimum or maximum) key with its value on the heap without removing it.
+// If the heap is empty, the second return value will be false.
+func (h *binomial[K, V]) Peek() (K, V, bool) {
+	if h.IsEmpty() {
+		var zeroK K
+		var zeroV V
+		return zeroK, zeroV, false
+	}
+
+	// Find the extermum (minimum in min heap or maximum in max heap) root.
+	var ext, curr *binomialNode[K, V]
+	for ext, curr = h.head, h.head; curr.sibling != nil; curr = curr.sibling {
+		if h.cmpKey(curr.sibling.key, ext.key) < 0 {
+			ext = curr.sibling
+		}
+	}
+
+	return ext.key, ext.val, true
+}
+
+// ContainsKey returns true if the given key is on the heap.
+func (h *binomial[K, V]) ContainsKey(key K) bool {
+	if h.IsEmpty() {
+		return false
+	}
+
+	// A false result indicates a match was found.
+	return !h._traverse(h.head, VLR, func(n *binomialNode[K, V]) bool {
+		// If a match is found, stop the traversal by returning false.
+		return h.cmpKey(n.key, key) != 0
+	})
+}
+
+// ContainsValue returns true if the given value is on the heap.
+func (h *binomial[K, V]) ContainsValue(val V) bool {
+	if h.IsEmpty() {
+		return false
+	}
+
+	// A false result indicates a match was found.
+	return !h._traverse(h.head, VLR, func(n *binomialNode[K, V]) bool {
+		// If a match is found, stop the traversal by returning false.
+		return !h.eqVal(n.val, val)
+	})
+}
+
+// Graphviz returns a visualization of the heap in Graphviz format.
+func (h *binomial[K, V]) Graphviz() string {
+	// Create a map of node --> id
+	var id int
+	nodeID := map[*binomialNode[K, V]]int{}
+	h._traverse(h.head, VLR, func(n *binomialNode[K, V]) bool {
+		id++
+		nodeID[n] = id
+		return true
+	})
+
+	graph := graphviz.NewGraph(true, true, false, "Binomial Heap", "", "", "", graphviz.ShapeMrecord)
+
+	h._traverse(h.head, VLR, func(n *binomialNode[K, V]) bool {
+		name := fmt.Sprintf("%d", nodeID[n])
+
+		rec := graphviz.NewRecord(
+			graphviz.NewSimpleField("", fmt.Sprintf("%v", n.key)),
+			graphviz.NewSimpleField("", fmt.Sprintf("%v", n.val)),
+		)
+
+		graph.AddNode(graphviz.NewNode(name, "", rec.Label(), "", "", "", "", ""))
+
+		if n.child != nil {
+			child := fmt.Sprintf("%d", nodeID[n.child])
+			graph.AddEdge(graphviz.NewEdge(name, child, graphviz.EdgeTypeDirected, "", "", graphviz.ColorBlue, "", "", ""))
+		}
+
+		if n.sibling != nil {
+			sibling := fmt.Sprintf("%d", nodeID[n.sibling])
+			graph.AddEdge(graphviz.NewEdge(name, sibling, graphviz.EdgeTypeDirected, "", "", graphviz.ColorRed, graphviz.StyleDashed, "", ""))
+		}
+
+		return true
+	})
+
+	return graph.DotCode()
+}
+
+// _traverse performs a depth-first traversal of the binomial heap,
+// visiting each node according to the specified traversal order.
+func (h *binomial[K, V]) _traverse(n *binomialNode[K, V], order TraverseOrder, visit func(*binomialNode[K, V]) bool) bool {
+	if n == nil {
+		return true
+	}
+
+	switch order {
+	case VLR:
+		return visit(n) && h._traverse(n.child, order, visit) && h._traverse(n.sibling, order, visit)
+	case VRL:
+		return visit(n) && h._traverse(n.sibling, order, visit) && h._traverse(n.child, order, visit)
+	case LVR:
+		return h._traverse(n.child, order, visit) && visit(n) && h._traverse(n.sibling, order, visit)
+	case RVL:
+		return h._traverse(n.sibling, order, visit) && visit(n) && h._traverse(n.child, order, visit)
+	case LRV:
+		return h._traverse(n.child, order, visit) && h._traverse(n.sibling, order, visit) && visit(n)
+	case RLV:
+		return h._traverse(n.sibling, order, visit) && h._traverse(n.child, order, visit) && visit(n)
+	default:
+		return false
+	}
+}

--- a/heap/binomial_test.go
+++ b/heap/binomial_test.go
@@ -1,0 +1,392 @@
+package heap
+
+import (
+	"testing"
+
+	. "github.com/moorara/algo/generic"
+)
+
+func getBinomialTests() []mergeableHeapTest[int, string] {
+	tests := getMergeableHeapTests()
+
+	tests[0].heap = "Binomial Min Heap"
+	tests[0].merge = nil
+	tests[0].expectedGraphviz = `strict digraph "Binomial Heap" {
+  concentrate=false;
+  node [shape=Mrecord];
+}`
+
+	tests[1].heap = "Binomial Max Heap"
+	tests[1].merge = nil
+	tests[1].expectedGraphviz = `strict digraph "Binomial Heap" {
+  concentrate=false;
+  node [shape=Mrecord];
+}`
+
+	tests[2].heap = "Binomial Min Heap"
+	tests[2].merge = NewBinomial(cmpMin, eqVal)
+	tests[2].merge.Insert(33, "Task#3.a")
+	tests[2].merge.Insert(11, "Task#1.a")
+	tests[2].merge.Insert(22, "Task#2.a")
+	tests[2].expectedSize += 3
+	tests[2].expectedPeek = KeyValue[int, string]{Key: 10, Val: "Task#1"}
+	tests[2].expectedContains = append(tests[2].expectedContains,
+		KeyValue[int, string]{Key: 11, Val: "Task#1.a"},
+		KeyValue[int, string]{Key: 22, Val: "Task#2.a"},
+		KeyValue[int, string]{Key: 33, Val: "Task#3.a"},
+	)
+	tests[2].expectedDelete = []KeyValue[int, string]{
+		{Key: 10, Val: "Task#1"},
+		{Key: 11, Val: "Task#1.a"},
+		{Key: 20, Val: "Task#2"},
+		{Key: 22, Val: "Task#2.a"},
+		{Key: 30, Val: "Task#3"},
+		{Key: 33, Val: "Task#3.a"},
+	}
+	tests[2].expectedGraphviz = `strict digraph "Binomial Heap" {
+  concentrate=false;
+  node [shape=Mrecord];
+
+  1 [label="20 | Task#2"];
+  2 [label="22 | Task#2.a"];
+  3 [label="10 | Task#1"];
+  4 [label="11 | Task#1.a"];
+  5 [label="33 | Task#3.a"];
+  6 [label="30 | Task#3"];
+
+  1 -> 2 [color=blue];
+  1 -> 3 [color=red, style=dashed];
+  3 -> 4 [color=blue];
+  4 -> 5 [color=blue];
+  4 -> 6 [color=red, style=dashed];
+}`
+
+	tests[3].heap = "Binomial Max Heap"
+	tests[3].merge = NewBinomial(cmpMax, eqVal)
+	tests[3].merge.Insert(11, "Task#1.a")
+	tests[3].merge.Insert(33, "Task#3.a")
+	tests[3].merge.Insert(22, "Task#2.a")
+	tests[3].expectedSize += 3
+	tests[3].expectedPeek = KeyValue[int, string]{Key: 33, Val: "Task#3.a"}
+	tests[3].expectedContains = append(tests[3].expectedContains,
+		KeyValue[int, string]{Key: 33, Val: "Task#3.a"},
+		KeyValue[int, string]{Key: 22, Val: "Task#2.a"},
+		KeyValue[int, string]{Key: 11, Val: "Task#1.a"},
+	)
+	tests[3].expectedDelete = []KeyValue[int, string]{
+		{Key: 33, Val: "Task#3.a"},
+		{Key: 30, Val: "Task#3"},
+		{Key: 22, Val: "Task#2.a"},
+		{Key: 20, Val: "Task#2"},
+		{Key: 11, Val: "Task#1.a"},
+		{Key: 10, Val: "Task#1"},
+	}
+	tests[3].expectedGraphviz = `strict digraph "Binomial Heap" {
+  concentrate=false;
+  node [shape=Mrecord];
+
+  1 [label="22 | Task#2.a"];
+  2 [label="20 | Task#2"];
+  3 [label="33 | Task#3.a"];
+  4 [label="30 | Task#3"];
+  5 [label="10 | Task#1"];
+  6 [label="11 | Task#1.a"];
+
+  1 -> 2 [color=blue];
+  1 -> 3 [color=red, style=dashed];
+  3 -> 4 [color=blue];
+  4 -> 5 [color=blue];
+  4 -> 6 [color=red, style=dashed];
+}`
+
+	tests[4].heap = "Binomial Min Heap"
+	tests[4].merge = NewBinomial(cmpMin, eqVal)
+	tests[4].merge.Insert(55, "Task#5.a")
+	tests[4].merge.Insert(33, "Task#3.a")
+	tests[4].merge.Insert(44, "Task#4.a")
+	tests[4].merge.Insert(11, "Task#1.a")
+	tests[4].merge.Insert(22, "Task#2.a")
+	tests[4].expectedSize += 5
+	tests[4].expectedPeek = KeyValue[int, string]{Key: 10, Val: "Task#1"}
+	tests[4].expectedContains = append(tests[4].expectedContains,
+		KeyValue[int, string]{Key: 11, Val: "Task#1.a"},
+		KeyValue[int, string]{Key: 22, Val: "Task#2.a"},
+		KeyValue[int, string]{Key: 33, Val: "Task#3.a"},
+		KeyValue[int, string]{Key: 44, Val: "Task#4.a"},
+		KeyValue[int, string]{Key: 55, Val: "Task#5.a"},
+	)
+	tests[4].expectedDelete = []KeyValue[int, string]{
+		{Key: 10, Val: "Task#1"},
+		{Key: 11, Val: "Task#1.a"},
+		{Key: 20, Val: "Task#2"},
+		{Key: 22, Val: "Task#2.a"},
+		{Key: 30, Val: "Task#3"},
+		{Key: 33, Val: "Task#3.a"},
+		{Key: 40, Val: "Task#4"},
+		{Key: 44, Val: "Task#4.a"},
+		{Key: 50, Val: "Task#5"},
+		{Key: 55, Val: "Task#5.a"},
+	}
+	tests[4].expectedGraphviz = `strict digraph "Binomial Heap" {
+  concentrate=false;
+  node [shape=Mrecord];
+
+  1 [label="20 | Task#2"];
+  2 [label="22 | Task#2.a"];
+  3 [label="10 | Task#1"];
+  4 [label="11 | Task#1.a"];
+  5 [label="33 | Task#3.a"];
+  6 [label="55 | Task#5.a"];
+  7 [label="44 | Task#4.a"];
+  8 [label="30 | Task#3"];
+  9 [label="50 | Task#5"];
+  10 [label="40 | Task#4"];
+
+  1 -> 2 [color=blue];
+  1 -> 3 [color=red, style=dashed];
+  3 -> 4 [color=blue];
+  4 -> 5 [color=blue];
+  4 -> 8 [color=red, style=dashed];
+  5 -> 6 [color=blue];
+  5 -> 7 [color=red, style=dashed];
+  8 -> 9 [color=blue];
+  8 -> 10 [color=red, style=dashed];
+}`
+
+	tests[5].heap = "Binomial Max Heap"
+	tests[5].merge = NewBinomial(cmpMax, eqVal)
+	tests[5].merge.Insert(11, "Task#1.a")
+	tests[5].merge.Insert(33, "Task#3.a")
+	tests[5].merge.Insert(22, "Task#2.a")
+	tests[5].merge.Insert(55, "Task#5.a")
+	tests[5].merge.Insert(44, "Task#4.a")
+	tests[5].expectedSize += 5
+	tests[5].expectedPeek = KeyValue[int, string]{Key: 55, Val: "Task#5.a"}
+	tests[5].expectedContains = append(tests[5].expectedContains,
+		KeyValue[int, string]{Key: 55, Val: "Task#5.a"},
+		KeyValue[int, string]{Key: 44, Val: "Task#4.a"},
+		KeyValue[int, string]{Key: 33, Val: "Task#3.a"},
+		KeyValue[int, string]{Key: 22, Val: "Task#2.a"},
+		KeyValue[int, string]{Key: 11, Val: "Task#1.a"},
+	)
+	tests[5].expectedDelete = []KeyValue[int, string]{
+		{Key: 55, Val: "Task#5.a"},
+		{Key: 50, Val: "Task#5"},
+		{Key: 44, Val: "Task#4.a"},
+		{Key: 40, Val: "Task#4"},
+		{Key: 33, Val: "Task#3.a"},
+		{Key: 30, Val: "Task#3"},
+		{Key: 22, Val: "Task#2.a"},
+		{Key: 20, Val: "Task#2"},
+		{Key: 11, Val: "Task#1.a"},
+		{Key: 10, Val: "Task#1"},
+	}
+	tests[5].expectedGraphviz = `strict digraph "Binomial Heap" {
+  concentrate=false;
+  node [shape=Mrecord];
+
+  1 [label="44 | Task#4.a"];
+  2 [label="40 | Task#4"];
+  3 [label="55 | Task#5.a"];
+  4 [label="50 | Task#5"];
+  5 [label="30 | Task#3"];
+  6 [label="10 | Task#1"];
+  7 [label="20 | Task#2"];
+  8 [label="33 | Task#3.a"];
+  9 [label="11 | Task#1.a"];
+  10 [label="22 | Task#2.a"];
+
+  1 -> 2 [color=blue];
+  1 -> 3 [color=red, style=dashed];
+  3 -> 4 [color=blue];
+  4 -> 5 [color=blue];
+  4 -> 8 [color=red, style=dashed];
+  5 -> 6 [color=blue];
+  5 -> 7 [color=red, style=dashed];
+  8 -> 9 [color=blue];
+  8 -> 10 [color=red, style=dashed];
+}`
+
+	tests[6].heap = "Binomial Min Heap"
+	tests[6].merge = NewBinomial(cmpMin, eqVal)
+	tests[6].merge.Insert(99, "Task#9.a")
+	tests[6].merge.Insert(88, "Task#8.a")
+	tests[6].merge.Insert(77, "Task#7.a")
+	tests[6].merge.Insert(44, "Task#4.a")
+	tests[6].merge.Insert(55, "Task#5.a")
+	tests[6].merge.Insert(66, "Task#6.a")
+	tests[6].merge.Insert(33, "Task#3.a")
+	tests[6].merge.Insert(11, "Task#1.a")
+	tests[6].merge.Insert(22, "Task#2.a")
+	tests[6].expectedSize += 9
+	tests[6].expectedPeek = KeyValue[int, string]{Key: 10, Val: "Task#1"}
+	tests[6].expectedContains = append(tests[6].expectedContains,
+		KeyValue[int, string]{Key: 11, Val: "Task#1.a"},
+		KeyValue[int, string]{Key: 22, Val: "Task#2.a"},
+		KeyValue[int, string]{Key: 33, Val: "Task#3.a"},
+		KeyValue[int, string]{Key: 44, Val: "Task#4.a"},
+		KeyValue[int, string]{Key: 55, Val: "Task#5.a"},
+		KeyValue[int, string]{Key: 66, Val: "Task#6.a"},
+		KeyValue[int, string]{Key: 77, Val: "Task#7.a"},
+		KeyValue[int, string]{Key: 88, Val: "Task#8.a"},
+		KeyValue[int, string]{Key: 99, Val: "Task#9.a"},
+	)
+	tests[6].expectedDelete = []KeyValue[int, string]{
+		{Key: 10, Val: "Task#1"},
+		{Key: 11, Val: "Task#1.a"},
+		{Key: 20, Val: "Task#2"},
+		{Key: 22, Val: "Task#2.a"},
+		{Key: 30, Val: "Task#3"},
+		{Key: 33, Val: "Task#3.a"},
+		{Key: 40, Val: "Task#4"},
+		{Key: 44, Val: "Task#4.a"},
+		{Key: 50, Val: "Task#5"},
+		{Key: 55, Val: "Task#5.a"},
+		{Key: 60, Val: "Task#6"},
+		{Key: 66, Val: "Task#6.a"},
+		{Key: 70, Val: "Task#7"},
+		{Key: 77, Val: "Task#7.a"},
+		{Key: 80, Val: "Task#8"},
+		{Key: 88, Val: "Task#8.a"},
+		{Key: 90, Val: "Task#9"},
+		{Key: 99, Val: "Task#9.a"},
+	}
+	tests[6].expectedGraphviz = `strict digraph "Binomial Heap" {
+  concentrate=false;
+  node [shape=Mrecord];
+
+  1 [label="20 | Task#2"];
+  2 [label="22 | Task#2.a"];
+  3 [label="10 | Task#1"];
+  4 [label="11 | Task#1.a"];
+  5 [label="44 | Task#4.a"];
+  6 [label="88 | Task#8.a"];
+  7 [label="99 | Task#9.a"];
+  8 [label="77 | Task#7.a"];
+  9 [label="55 | Task#5.a"];
+  10 [label="66 | Task#6.a"];
+  11 [label="33 | Task#3.a"];
+  12 [label="40 | Task#4"];
+  13 [label="80 | Task#8"];
+  14 [label="90 | Task#9"];
+  15 [label="70 | Task#7"];
+  16 [label="50 | Task#5"];
+  17 [label="60 | Task#6"];
+  18 [label="30 | Task#3"];
+
+  1 -> 2 [color=blue];
+  1 -> 3 [color=red, style=dashed];
+  3 -> 4 [color=blue];
+  4 -> 5 [color=blue];
+  4 -> 12 [color=red, style=dashed];
+  5 -> 6 [color=blue];
+  5 -> 9 [color=red, style=dashed];
+  6 -> 7 [color=blue];
+  6 -> 8 [color=red, style=dashed];
+  9 -> 10 [color=blue];
+  9 -> 11 [color=red, style=dashed];
+  12 -> 13 [color=blue];
+  12 -> 16 [color=red, style=dashed];
+  13 -> 14 [color=blue];
+  13 -> 15 [color=red, style=dashed];
+  16 -> 17 [color=blue];
+  16 -> 18 [color=red, style=dashed];
+}`
+
+	tests[7].heap = "Binomial Max Heap"
+	tests[7].merge = NewBinomial(cmpMax, eqVal)
+	tests[7].merge.Insert(11, "Task#1.a")
+	tests[7].merge.Insert(33, "Task#3.a")
+	tests[7].merge.Insert(22, "Task#2.a")
+	tests[7].merge.Insert(55, "Task#5.a")
+	tests[7].merge.Insert(44, "Task#4.a")
+	tests[7].merge.Insert(66, "Task#6.a")
+	tests[7].merge.Insert(77, "Task#7.a")
+	tests[7].merge.Insert(99, "Task#9.a")
+	tests[7].merge.Insert(88, "Task#8.a")
+	tests[7].expectedSize += 9
+	tests[7].expectedPeek = KeyValue[int, string]{Key: 99, Val: "Task#9.a"}
+	tests[7].expectedContains = append(tests[7].expectedContains,
+		KeyValue[int, string]{Key: 99, Val: "Task#9.a"},
+		KeyValue[int, string]{Key: 88, Val: "Task#8.a"},
+		KeyValue[int, string]{Key: 77, Val: "Task#7.a"},
+		KeyValue[int, string]{Key: 66, Val: "Task#6.a"},
+		KeyValue[int, string]{Key: 55, Val: "Task#5.a"},
+		KeyValue[int, string]{Key: 44, Val: "Task#4.a"},
+		KeyValue[int, string]{Key: 33, Val: "Task#3.a"},
+		KeyValue[int, string]{Key: 22, Val: "Task#2.a"},
+		KeyValue[int, string]{Key: 11, Val: "Task#1.a"},
+	)
+	tests[7].expectedDelete = []KeyValue[int, string]{
+		{Key: 99, Val: "Task#9.a"},
+		{Key: 90, Val: "Task#9"},
+		{Key: 88, Val: "Task#8.a"},
+		{Key: 80, Val: "Task#8"},
+		{Key: 77, Val: "Task#7.a"},
+		{Key: 70, Val: "Task#7"},
+		{Key: 66, Val: "Task#6.a"},
+		{Key: 60, Val: "Task#6"},
+		{Key: 55, Val: "Task#5.a"},
+		{Key: 50, Val: "Task#5"},
+		{Key: 44, Val: "Task#4.a"},
+		{Key: 40, Val: "Task#4"},
+		{Key: 33, Val: "Task#3.a"},
+		{Key: 30, Val: "Task#3"},
+		{Key: 22, Val: "Task#2.a"},
+		{Key: 20, Val: "Task#2"},
+		{Key: 11, Val: "Task#1.a"},
+		{Key: 10, Val: "Task#1"},
+	}
+	tests[7].expectedGraphviz = `strict digraph "Binomial Heap" {
+  concentrate=false;
+  node [shape=Mrecord];
+
+  1 [label="88 | Task#8.a"];
+  2 [label="80 | Task#8"];
+  3 [label="99 | Task#9.a"];
+  4 [label="90 | Task#9"];
+  5 [label="50 | Task#5"];
+  6 [label="30 | Task#3"];
+  7 [label="10 | Task#1"];
+  8 [label="20 | Task#2"];
+  9 [label="60 | Task#6"];
+  10 [label="40 | Task#4"];
+  11 [label="70 | Task#7"];
+  12 [label="55 | Task#5.a"];
+  13 [label="33 | Task#3.a"];
+  14 [label="11 | Task#1.a"];
+  15 [label="22 | Task#2.a"];
+  16 [label="66 | Task#6.a"];
+  17 [label="44 | Task#4.a"];
+  18 [label="77 | Task#7.a"];
+
+  1 -> 2 [color=blue];
+  1 -> 3 [color=red, style=dashed];
+  3 -> 4 [color=blue];
+  4 -> 5 [color=blue];
+  4 -> 12 [color=red, style=dashed];
+  5 -> 6 [color=blue];
+  5 -> 9 [color=red, style=dashed];
+  6 -> 7 [color=blue];
+  6 -> 8 [color=red, style=dashed];
+  9 -> 10 [color=blue];
+  9 -> 11 [color=red, style=dashed];
+  12 -> 13 [color=blue];
+  12 -> 16 [color=red, style=dashed];
+  13 -> 14 [color=blue];
+  13 -> 15 [color=red, style=dashed];
+  16 -> 17 [color=blue];
+  16 -> 18 [color=red, style=dashed];
+}`
+
+	return tests
+}
+
+func TestBinomialHeap(t *testing.T) {
+	tests := getBinomialTests()
+
+	for _, tc := range tests {
+		heap := NewBinomial(tc.cmpKey, tc.eqVal)
+		runMergeableHeapTest(t, heap, tc)
+	}
+}

--- a/heap/heap_test.go
+++ b/heap/heap_test.go
@@ -52,11 +52,9 @@ type indexedHeapTest[K, V any] struct {
 	expectedGraphviz    string
 }
 
-// nolint: unused
 type mergeableHeapTest[K, V any] struct {
 	name             string
 	heap             string
-	size             int
 	cmpKey           CompareFunc[K]
 	eqVal            EqualFunc[V]
 	inserts          []KeyValue[K, V]
@@ -627,16 +625,13 @@ func getIndexedHeapTests() []indexedHeapTest[int, string] {
 	}
 }
 
-// nolint: unused
-func getMergeableHeapTest() []mergeableHeapTest[int, string] {
+func getMergeableHeapTests() []mergeableHeapTest[int, string] {
 	return []mergeableHeapTest[int, string]{
 		{
 			name:             "MinHeap_Empty",
-			size:             2,
 			cmpKey:           cmpMin,
 			eqVal:            eqVal,
 			inserts:          []KeyValue[int, string]{},
-			merge:            nil,
 			expectedSize:     0,
 			expectedIsEmpty:  true,
 			expectedPeek:     KeyValue[int, string]{Key: 0, Val: ""},
@@ -645,11 +640,9 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 		},
 		{
 			name:             "MaxHeap_Empty",
-			size:             2,
 			cmpKey:           cmpMax,
 			eqVal:            eqVal,
 			inserts:          []KeyValue[int, string]{},
-			merge:            nil,
 			expectedSize:     0,
 			expectedIsEmpty:  true,
 			expectedPeek:     KeyValue[int, string]{Key: 0, Val: ""},
@@ -658,7 +651,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 		},
 		{
 			name:   "MinHeap_FewItems",
-			size:   2,
 			cmpKey: cmpMin,
 			eqVal:  eqVal,
 			inserts: []KeyValue[int, string]{
@@ -666,7 +658,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 				{Key: 10, Val: "Task#1"},
 				{Key: 20, Val: "Task#2"},
 			},
-			merge:           nil,
 			expectedSize:    3,
 			expectedIsEmpty: false,
 			expectedPeek:    KeyValue[int, string]{Key: 10, Val: "Task#1"},
@@ -683,7 +674,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 		},
 		{
 			name:   "MaxHeap_FewItems",
-			size:   2,
 			cmpKey: cmpMax,
 			eqVal:  eqVal,
 			inserts: []KeyValue[int, string]{
@@ -691,7 +681,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 				{Key: 30, Val: "Task#3"},
 				{Key: 20, Val: "Task#2"},
 			},
-			merge:           nil,
 			expectedSize:    3,
 			expectedIsEmpty: false,
 			expectedPeek:    KeyValue[int, string]{Key: 30, Val: "Task#3"},
@@ -708,7 +697,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 		},
 		{
 			name:   "MinHeap_SomeItems",
-			size:   4,
 			cmpKey: cmpMin,
 			eqVal:  eqVal,
 			inserts: []KeyValue[int, string]{
@@ -718,7 +706,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 				{Key: 10, Val: "Task#1"},
 				{Key: 20, Val: "Task#2"},
 			},
-			merge:           nil,
 			expectedSize:    5,
 			expectedIsEmpty: false,
 			expectedPeek:    KeyValue[int, string]{Key: 10, Val: "Task#1"},
@@ -739,7 +726,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 		},
 		{
 			name:   "MaxHeap_SomeItems",
-			size:   4,
 			cmpKey: cmpMax,
 			eqVal:  eqVal,
 			inserts: []KeyValue[int, string]{
@@ -749,7 +735,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 				{Key: 50, Val: "Task#5"},
 				{Key: 40, Val: "Task#4"},
 			},
-			merge:           nil,
 			expectedSize:    5,
 			expectedIsEmpty: false,
 			expectedPeek:    KeyValue[int, string]{Key: 50, Val: "Task#5"},
@@ -770,7 +755,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 		},
 		{
 			name:   "MinHeap_ManyItems",
-			size:   4,
 			cmpKey: cmpMin,
 			eqVal:  eqVal,
 			inserts: []KeyValue[int, string]{
@@ -784,7 +768,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 				{Key: 10, Val: "Task#1"},
 				{Key: 20, Val: "Task#2"},
 			},
-			merge:           nil,
 			expectedSize:    9,
 			expectedIsEmpty: false,
 			expectedPeek:    KeyValue[int, string]{Key: 10, Val: "Task#1"},
@@ -813,7 +796,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 		},
 		{
 			name:   "MaxHeap_ManyItems",
-			size:   4,
 			cmpKey: cmpMax,
 			eqVal:  eqVal,
 			inserts: []KeyValue[int, string]{
@@ -827,7 +809,6 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 				{Key: 90, Val: "Task#9"},
 				{Key: 80, Val: "Task#8"},
 			},
-			merge:           nil,
 			expectedSize:    9,
 			expectedIsEmpty: false,
 			expectedPeek:    KeyValue[int, string]{Key: 90, Val: "Task#9"},
@@ -858,7 +839,7 @@ func getMergeableHeapTest() []mergeableHeapTest[int, string] {
 }
 
 // nolint: unused
-func getIndexedMergeableHeapTest() []indexedMergeableHeapTest[int, string] {
+func getIndexedMergeableHeapTests() []indexedMergeableHeapTest[int, string] {
 	return []indexedMergeableHeapTest[int, string]{
 		{
 			name:                "MinHeap_Empty",
@@ -867,7 +848,6 @@ func getIndexedMergeableHeapTest() []indexedMergeableHeapTest[int, string] {
 			eqVal:               eqVal,
 			inserts:             []indexedKeyValue[int, string]{},
 			changeKeys:          []indexedKeyValue[int, string]{},
-			merge:               nil,
 			expectedSize:        0,
 			expectedIsEmpty:     true,
 			expectedPeek:        indexedKeyValue[int, string]{},
@@ -883,7 +863,6 @@ func getIndexedMergeableHeapTest() []indexedMergeableHeapTest[int, string] {
 			eqVal:               eqVal,
 			inserts:             []indexedKeyValue[int, string]{},
 			changeKeys:          []indexedKeyValue[int, string]{},
-			merge:               nil,
 			expectedSize:        0,
 			expectedIsEmpty:     true,
 			expectedPeek:        indexedKeyValue[int, string]{},
@@ -906,7 +885,6 @@ func getIndexedMergeableHeapTest() []indexedMergeableHeapTest[int, string] {
 				{index: 1, key: 10},
 				{index: 2, key: 20},
 			},
-			merge:           nil,
 			expectedSize:    3,
 			expectedIsEmpty: false,
 			expectedPeek:    indexedKeyValue[int, string]{1, 10, "Task#1"},
@@ -942,7 +920,6 @@ func getIndexedMergeableHeapTest() []indexedMergeableHeapTest[int, string] {
 				{index: 1, key: 30},
 				{index: 2, key: 20},
 			},
-			merge:           nil,
 			expectedSize:    3,
 			expectedIsEmpty: false,
 			expectedPeek:    indexedKeyValue[int, string]{1, 30, "Task#3"},
@@ -981,7 +958,6 @@ func getIndexedMergeableHeapTest() []indexedMergeableHeapTest[int, string] {
 				{index: 3, key: 10},
 				{index: 4, key: 20},
 			},
-			merge:           nil,
 			expectedSize:    5,
 			expectedIsEmpty: false,
 			expectedPeek:    indexedKeyValue[int, string]{3, 10, "Task#1"},
@@ -1026,7 +1002,6 @@ func getIndexedMergeableHeapTest() []indexedMergeableHeapTest[int, string] {
 				{index: 3, key: 50},
 				{index: 4, key: 40},
 			},
-			merge:           nil,
 			expectedSize:    5,
 			expectedIsEmpty: false,
 			expectedPeek:    indexedKeyValue[int, string]{3, 50, "Task#5"},
@@ -1077,7 +1052,6 @@ func getIndexedMergeableHeapTest() []indexedMergeableHeapTest[int, string] {
 				{index: 7, key: 10},
 				{index: 8, key: 20},
 			},
-			merge:           nil,
 			expectedSize:    9,
 			expectedIsEmpty: false,
 			expectedPeek:    indexedKeyValue[int, string]{7, 10, "Task#1"},
@@ -1140,7 +1114,6 @@ func getIndexedMergeableHeapTest() []indexedMergeableHeapTest[int, string] {
 				{index: 7, key: 90},
 				{index: 8, key: 80},
 			},
-			merge:           nil,
 			expectedSize:    9,
 			expectedIsEmpty: false,
 			expectedPeek:    indexedKeyValue[int, string]{7, 90, "Task#9"},
@@ -1424,7 +1397,6 @@ func runIndexedHeapTest(t *testing.T, heap IndexedHeap[int, string], test indexe
 	})
 }
 
-// nolint: unused
 func runMergeableHeapTest(t *testing.T, heap MergeableHeap[int, string], test mergeableHeapTest[int, string]) {
 	t.Run(test.name, func(t *testing.T) {
 		t.Run("Before", func(t *testing.T) {

--- a/heap/indexed_binary_test.go
+++ b/heap/indexed_binary_test.go
@@ -134,7 +134,7 @@ func TestIndexedBinaryHeap(t *testing.T) {
 	tests := getIndexedBinaryTests()
 
 	for _, tc := range tests {
-		heap := NewIndexedBinary[int, string](tc.cap, tc.cmpKey, tc.eqVal)
+		heap := NewIndexedBinary(tc.cap, tc.cmpKey, tc.eqVal)
 		runIndexedHeapTest(t, heap, tc)
 	}
 }


### PR DESCRIPTION
## Description

Related to #8

  - [x] Implement **Binomial Heap**
  - [x] Misc refactoring for `heap` package

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
