### PR TITLE
breaking IndexedHeap interface: return false instead of panicing

### DIFF
--- a/heap/heap.go
+++ b/heap/heap.go
@@ -20,8 +20,8 @@ type Heap[K, V any] interface {
 type IndexedHeap[K, V any] interface {
 	Size() int
 	IsEmpty() bool
-	Insert(int, K, V)
-	ChangeKey(int, K)
+	Insert(int, K, V) bool
+	ChangeKey(int, K) bool
 	Delete() (int, K, V, bool)
 	DeleteIndex(int) (K, V, bool)
 	DeleteAll()

--- a/heap/heap_test.go
+++ b/heap/heap_test.go
@@ -946,14 +946,27 @@ func runIndexedHeapTest(t *testing.T, heap IndexedHeap[int, string], test indexe
 
 		t.Run("Insert", func(t *testing.T) {
 			for _, kv := range test.inserts {
-				heap.Insert(kv.index, kv.key, kv.val)
+				ok := heap.Insert(kv.index, kv.key, kv.val)
+				assert.True(t, ok)
+			}
+
+			// Try inserting an index already on the heap.
+			if len(test.inserts) > 0 {
+				kv := test.inserts[0]
+				ok := heap.Insert(kv.index, kv.key, kv.val)
+				assert.False(t, ok)
 			}
 		})
 
 		t.Run("ChangeKey", func(t *testing.T) {
 			for _, kv := range test.changeKeys {
-				heap.ChangeKey(kv.index, kv.key)
+				ok := heap.ChangeKey(kv.index, kv.key)
+				assert.True(t, ok)
 			}
+
+			// Try changing the key for an index not on the heap.
+			ok := heap.ChangeKey(-1, 69)
+			assert.False(t, ok)
 		})
 
 		t.Run("Size", func(t *testing.T) {

--- a/heap/indexed_binary.go
+++ b/heap/indexed_binary.go
@@ -43,12 +43,6 @@ func NewIndexedBinary[K, V any](cap int, cmpKey CompareFunc[K], eqVal EqualFunc[
 	}
 }
 
-func (h *indexedBinary[K, V]) validateIndex(i int) {
-	if i < 0 || i >= len(h.kvs) {
-		panic("index is out of range")
-	}
-}
-
 // compare compares two keys on the heap by their positions.
 func (h *indexedBinary[K, V]) compare(a, b int) int {
 	i, j := h.heap[a], h.heap[b]
@@ -95,10 +89,10 @@ func (h *indexedBinary[K, V]) IsEmpty() bool {
 }
 
 // Insert adds a new key-value pair to the heap with an associated index.
-func (h *indexedBinary[K, V]) Insert(i int, key K, val V) {
+func (h *indexedBinary[K, V]) Insert(i int, key K, val V) bool {
 	// ContainsIndex validates the index too.
 	if h.ContainsIndex(i) {
-		panic(fmt.Sprintf("index %d is already on the heap", i))
+		return false
 	}
 
 	h.n++
@@ -110,18 +104,22 @@ func (h *indexedBinary[K, V]) Insert(i int, key K, val V) {
 	}
 
 	h.promote(h.n)
+
+	return true
 }
 
 // ChangeKey changes the key associated with an index.
-func (h *indexedBinary[K, V]) ChangeKey(i int, key K) {
+func (h *indexedBinary[K, V]) ChangeKey(i int, key K) bool {
 	// ContainsIndex validates the index too.
 	if !h.ContainsIndex(i) {
-		panic(fmt.Sprintf("index %d is not on the heap", i))
+		return false
 	}
 
 	h.kvs[i].Key = key
 	h.promote(h.pos[i])
 	h.demote(h.pos[i])
+
+	return true
 }
 
 // Delete removes the extremum (minimum or maximum) key with its value and index on the heap.
@@ -212,8 +210,7 @@ func (h *indexedBinary[K, V]) PeekIndex(i int) (K, V, bool) {
 
 // ContainsIndex returns true if a given index is on the heap.
 func (h *indexedBinary[K, V]) ContainsIndex(i int) bool {
-	h.validateIndex(i)
-	return h.pos[i] != -1
+	return 0 <= i && i < len(h.kvs) && h.pos[i] != -1
 }
 
 // ContainsKey returns true if a given key is on the heap.


### PR DESCRIPTION
## Description

  - [x] Returning false for `IndexedHeap.Insert()` and `IndexedHeap.ChangeKey()` instead of panicing.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
