### PR TITLE
Add Collect1 and Collect2 functions to generic package

### DIFF
--- a/automata/partition.go
+++ b/automata/partition.go
@@ -123,7 +123,7 @@ func (p *partition) BuildGroupTrans(dfa *DFA, G group) doubleKeyMap[State, Symbo
 // if and only if, for all input symbols a, the transitions of s and t on a lead to states in the same group.
 // If no such grouping is possible, a state will be placed in a subgroup by itself.
 func (p *partition) PartitionAndAddGroups(Gtrans doubleKeyMap[State, Symbol, State]) {
-	pairs := Collect(Gtrans.All())
+	pairs := Collect2(Gtrans.All())
 
 	for i := 0; i < len(pairs); i++ {
 		s, strans := pairs[i].Key, pairs[i].Val

--- a/generic/collection.go
+++ b/generic/collection.go
@@ -101,8 +101,18 @@ type KeyValue[K, V any] struct {
 	Val V
 }
 
-// Collect collects key-values in a collection from seq2 into a new slice and returns it.
-func Collect[K, V any](seq2 iter.Seq2[K, V]) []KeyValue[K, V] {
+// Collect1 collects items in a collection from seq into a new slice and returns it.
+func Collect1[T any](seq iter.Seq[T]) []T {
+	items := make([]T, 0)
+	for v := range seq {
+		items = append(items, v)
+	}
+
+	return items
+}
+
+// Collect2 collects key-values in a collection from seq2 into a new slice and returns it.
+func Collect2[K, V any](seq2 iter.Seq2[K, V]) []KeyValue[K, V] {
 	kvs := make([]KeyValue[K, V], 0)
 	for k, v := range seq2 {
 		kvs = append(kvs, KeyValue[K, V]{k, v})

--- a/generic/collection_test.go
+++ b/generic/collection_test.go
@@ -7,17 +7,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type testCollection[K comparable, V any] struct {
+type testCollection1[T any] struct {
+	items []T
+}
+
+func (c *testCollection1[T]) Add(vals ...T) {
+	c.items = append(c.items, vals...)
+}
+
+func (c *testCollection1[T]) All() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for _, v := range c.items {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+type testCollection2[K comparable, V any] struct {
 	keys []K
 	vals []V
 }
 
-func (c *testCollection[K, V]) Add(key K, val V) {
+func (c *testCollection2[K, V]) Put(key K, val V) {
 	c.keys = append(c.keys, key)
 	c.vals = append(c.vals, val)
 }
 
-func (c *testCollection[K, V]) All() iter.Seq2[K, V] {
+func (c *testCollection2[K, V]) All() iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		for i := range c.keys {
 			if !yield(c.keys[i], c.vals[i]) {
@@ -27,16 +45,26 @@ func (c *testCollection[K, V]) All() iter.Seq2[K, V] {
 	}
 }
 
-func TestCollect(t *testing.T) {
-	c := new(testCollection[string, int])
-	c.Add("foo", 1)
-	c.Add("bar", 2)
+func TestCollect1(t *testing.T) {
+	c := new(testCollection1[string])
+	c.Add("foo", "bar")
+
+	expectedSlice := []string{"foo", "bar"}
+
+	slice := Collect1(c.All())
+	assert.Equal(t, expectedSlice, slice)
+}
+
+func TestCollect2(t *testing.T) {
+	c := new(testCollection2[string, int])
+	c.Put("foo", 1)
+	c.Put("bar", 2)
 
 	expectedSlice := []KeyValue[string, int]{
 		{"foo", 1},
 		{"bar", 2},
 	}
 
-	slice := Collect(c.All())
+	slice := Collect2(c.All())
 	assert.Equal(t, expectedSlice, slice)
 }

--- a/grammar/production.go
+++ b/grammar/production.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"iter"
-	"slices"
 
 	. "github.com/moorara/algo/generic"
 	"github.com/moorara/algo/set"
@@ -192,7 +191,7 @@ func (p *productions) Get(head NonTerminal) set.Set[Production] {
 // The goal of this function is to ensure a consistent and deterministic order for any given set of production rules.
 func (p *productions) Order(head NonTerminal) []Production {
 	// Collect all production rules into a slice from the set iterator.
-	prods := slices.Collect(p.Get(head).All())
+	prods := Collect1(p.Get(head).All())
 
 	// Sort the productions using a custom comparison function.
 	sort.Quick[Production](prods, func(lhs, rhs Production) int {

--- a/set/set.go
+++ b/set/set.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"iter"
 	"math/rand"
-	"slices"
 	"strings"
 	"time"
 
@@ -281,7 +280,7 @@ func Powerset[T any](s Set[T]) Set[Set[T]] {
 		return PS
 	}
 
-	members := slices.Collect(s.All())
+	members := Collect1(s.All())
 	head, tail := s.CloneEmpty(), s.CloneEmpty()
 	head.Add(members[0])
 	tail.Add(members[1:]...)
@@ -317,14 +316,14 @@ func Partitions[T any](s Set[T]) Set[Set[Set[T]]] {
 		return Ps
 	}
 
-	members := slices.Collect(s.All())
+	members := Collect1(s.All())
 	head, tail := s.CloneEmpty(), s.CloneEmpty()
 	head.Add(members[0])
 	tail.Add(members[1:]...)
 
 	// For every partition of s[1:]
 	for P := range Partitions[T](tail).All() {
-		Pmembers := slices.Collect(P.All())
+		Pmembers := Collect1(P.All())
 
 		// Prepend s[0] to the curret partition
 		Q := New[Set[T]](setEqFunc)

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -1,7 +1,6 @@
 package set
 
 import (
-	"slices"
 	"strings"
 	"testing"
 
@@ -385,7 +384,7 @@ func TestSet_All(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			members := slices.Collect(tc.s.All())
+			members := Collect1(tc.s.All())
 
 			for _, expectedMember := range tc.expectedMembers {
 				assert.Contains(t, members, expectedMember)

--- a/symboltable/symbol_table_test.go
+++ b/symboltable/symbol_table_test.go
@@ -836,7 +836,7 @@ func runSymbolTableTest(t *testing.T, st SymbolTable[string, int], test symbolTa
 
 		t.Run("All", func(t *testing.T) {
 			// The key-values are unordered, so we need to compare the lists pair-wise.
-			all := Collect(st.All())
+			all := Collect2(st.All())
 
 			for _, kv := range test.expectedAll {
 				assert.Contains(t, all, kv)
@@ -858,7 +858,7 @@ func runSymbolTableTest(t *testing.T, st SymbolTable[string, int], test symbolTa
 		})
 
 		t.Run("SelectMatch", func(t *testing.T) {
-			selectMatch := Collect(st.SelectMatch(test.selectMatchPredicate).All())
+			selectMatch := Collect2(st.SelectMatch(test.selectMatchPredicate).All())
 
 			for _, kv := range test.expectedSelectMatch {
 				assert.Contains(t, selectMatch, kv)
@@ -1056,7 +1056,7 @@ func runOrderedSymbolTableTest(t *testing.T, ost OrderedSymbolTable[string, int]
 
 		t.Run("All", func(t *testing.T) {
 			// The key-values are ordered, so we can directly compare the lists.
-			all := Collect(ost.All())
+			all := Collect2(ost.All())
 			assert.Equal(t, test.expectedAll, all)
 		})
 
@@ -1071,7 +1071,7 @@ func runOrderedSymbolTableTest(t *testing.T, ost OrderedSymbolTable[string, int]
 		})
 
 		t.Run("SelectMatch", func(t *testing.T) {
-			selectMatch := Collect(ost.SelectMatch(test.selectMatchPredicate).All())
+			selectMatch := Collect2(ost.SelectMatch(test.selectMatchPredicate).All())
 			assert.Equal(t, test.expectedSelectMatch, selectMatch)
 		})
 

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -531,7 +531,7 @@ func runTrieTest(t *testing.T, trie Trie[int], test trieTest[int]) {
 		})
 
 		t.Run("All", func(t *testing.T) {
-			kvs = Collect(trie.All())
+			kvs = Collect2(trie.All())
 			assert.Equal(t, test.expectedAll, kvs)
 		})
 
@@ -546,7 +546,7 @@ func runTrieTest(t *testing.T, trie Trie[int], test trieTest[int]) {
 		})
 
 		t.Run("SelectMatch", func(t *testing.T) {
-			selectMatch := Collect(trie.SelectMatch(test.selectMatchPredicate).All())
+			selectMatch := Collect2(trie.SelectMatch(test.selectMatchPredicate).All())
 			assert.Equal(t, test.expectedSelectMatch, selectMatch)
 		})
 


### PR DESCRIPTION
Resolves #239 

## Description

  - [x] Add the `Collect1` function to the `generic` package.
  - [x] Rename the `Collect` function to `Collect2` in the `generic` package.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
