### PR TITLE
Add errors package

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,2 @@
+// Package errors
+package errors

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,19 @@
+package errors
+
+type fooError struct{}
+
+func (e *fooError) Error() string {
+	return "error on foo"
+}
+
+type barError struct{}
+
+func (e *barError) Error() string {
+	return "error on bar"
+}
+
+type bazError struct{}
+
+func (e *bazError) Error() string {
+	return "error on baz\nsomething failed"
+}

--- a/errors/format.go
+++ b/errors/format.go
@@ -1,0 +1,59 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+)
+
+// errorFormat is a function type for formatting a slice of errors into a single string representation.
+type ErrorFormat func([]error) string
+
+var (
+	// DefaultErrorFormat formats a slice of errors into a single string,
+	// with each error on a new line.
+	DefaultErrorFormat = defaultErrorFormat
+
+	// BulletErrorFormat formats a slice of errors into a single string,
+	// with each error indented, prefixed by a bullet point, and properly spaced.
+	BulletErrorFormat = bulletErrorFormat
+)
+
+func defaultErrorFormat(errs []error) string {
+	if len(errs) == 0 {
+		return ""
+	}
+
+	b := new(strings.Builder)
+
+	for _, err := range errs {
+		fmt.Fprintln(b, err)
+	}
+
+	return b.String()
+}
+
+func bulletErrorFormat(errs []error) string {
+	if len(errs) == 0 {
+		return ""
+	}
+
+	b := new(strings.Builder)
+
+	if len(errs) == 1 {
+		b.WriteString("1 error occurred:\n\n")
+	} else {
+		fmt.Fprintf(b, "%d errors occurred:\n\n", len(errs))
+	}
+
+	for _, err := range errs {
+		for i, line := range strings.Split(err.Error(), "\n") {
+			if i == 0 {
+				fmt.Fprintf(b, "  • %s\n", line)
+			} else {
+				fmt.Fprintf(b, "    %s\n", line)
+			}
+		}
+	}
+
+	return b.String()
+}

--- a/errors/format_test.go
+++ b/errors/format_test.go
@@ -1,0 +1,91 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultErrorFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		errs           []error
+		expectedString string
+	}{
+		{
+			name:           "Nil",
+			errs:           nil,
+			expectedString: "",
+		},
+		{
+			name:           "Zero",
+			errs:           []error{},
+			expectedString: "",
+		},
+		{
+			name: "One",
+			errs: []error{
+				new(fooError),
+			},
+			expectedString: "error on foo\n",
+		},
+		{
+			name: "Multiple",
+			errs: []error{
+				new(fooError),
+				new(barError),
+				new(bazError),
+			},
+			expectedString: "error on foo\nerror on bar\nerror on baz\nsomething failed\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := DefaultErrorFormat(tc.errs)
+			assert.Equal(t, tc.expectedString, s)
+		})
+	}
+}
+
+func TestBulletErrorFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		errs           []error
+		expectedString string
+	}{
+		{
+			name:           "Nil",
+			errs:           nil,
+			expectedString: "",
+		},
+		{
+			name:           "Zero",
+			errs:           []error{},
+			expectedString: "",
+		},
+		{
+			name: "One",
+			errs: []error{
+				new(fooError),
+			},
+			expectedString: "1 error occurred:\n\n  • error on foo\n",
+		},
+		{
+			name: "Multiple",
+			errs: []error{
+				new(fooError),
+				new(barError),
+				new(bazError),
+			},
+			expectedString: "3 errors occurred:\n\n  • error on foo\n  • error on bar\n  • error on baz\n    something failed\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := BulletErrorFormat(tc.errs)
+			assert.Equal(t, tc.expectedString, s)
+		})
+	}
+}

--- a/errors/group.go
+++ b/errors/group.go
@@ -1,0 +1,38 @@
+package errors
+
+import "sync"
+
+// Group is used for aggregating multiple errors from multiple goroutines.
+// It provides thread-safe methods to run functions concurrently and collect any errors they return.
+type Group struct {
+	wg  sync.WaitGroup
+	mu  sync.Mutex
+	err *MultiError
+}
+
+// Go starts a new goroutine to execute the given function f.
+// If f returns an error, it will be safely added to the aggregated errors.
+func (e *Group) Go(f func() error) {
+	e.wg.Add(1)
+
+	go func() {
+		defer e.wg.Done()
+
+		if err := f(); err != nil {
+			e.mu.Lock()
+			e.err = Append(e.err, err)
+			e.mu.Unlock()
+		}
+	}()
+}
+
+// Wait blocks until all goroutines started with the Go method have finished.
+// It returns the aggregated errors from all goroutines.
+// If no errors were returned, it returns nil.
+func (e *Group) Wait() *MultiError {
+	e.wg.Wait()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.err
+}

--- a/errors/group_test.go
+++ b/errors/group_test.go
@@ -1,0 +1,72 @@
+package errors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupError(t *testing.T) {
+	tests := []struct {
+		name               string
+		funcs              []func() error
+		expectedMultiError *MultiError
+	}{
+		{
+			name: "WithoutErrors",
+			funcs: []func() error{
+				func() error {
+					time.Sleep(20 * time.Millisecond)
+					return nil
+				},
+				func() error {
+					time.Sleep(10 * time.Millisecond)
+					return nil
+				},
+				func() error {
+					time.Sleep(30 * time.Millisecond)
+					return nil
+				},
+			},
+			expectedMultiError: nil,
+		},
+		{
+			name: "WithErrors",
+			funcs: []func() error{
+				func() error {
+					time.Sleep(20 * time.Millisecond)
+					return new(fooError)
+				},
+				func() error {
+					time.Sleep(10 * time.Millisecond)
+					return new(barError)
+				},
+				func() error {
+					time.Sleep(30 * time.Millisecond)
+					return new(bazError)
+				},
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(barError),
+					new(fooError),
+					new(bazError),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := new(Group)
+
+			for _, f := range tc.funcs {
+				g.Go(f)
+			}
+
+			err := g.Wait()
+			assert.Equal(t, tc.expectedMultiError, err)
+		})
+	}
+}

--- a/errors/multi_error.go
+++ b/errors/multi_error.go
@@ -1,0 +1,111 @@
+package errors
+
+import "errors"
+
+// Append adds one or more errors to an existing error and returns a MultiError instance.
+//
+//   - If the input error e is nil, a new instance of MultiError is created.
+//   - If e is not already an instance of MultiError, it will be wrapped into a new MultiError instance.
+//   - If any of the provided errors (errs) are instances of MultiError, they are flattened into the result.
+func Append(e error, errs ...error) *MultiError {
+	var me *MultiError
+
+	if e == nil || e == me {
+		me = new(MultiError)
+	} else {
+		switch e := e.(type) {
+		case *MultiError:
+			me = e
+		default:
+			// Wrap the existing error e into a new MultiError instance.
+			me = new(MultiError)
+			me.errs = make([]error, 0, len(errs)+1)
+			me.errs = append(me.errs, e)
+		}
+	}
+
+	// Iterate through the provided errors and flatten any instances of MultiError.
+	for _, err := range errs {
+		if err != nil {
+			switch err := err.(type) {
+			case *MultiError:
+				me.errs = append(me.errs, err.errs...)
+			default:
+				me.errs = append(me.errs, err)
+			}
+		}
+	}
+
+	// If no errors were accumulated, return nil.
+	// This ensures the behavior of MultiError stays consistent with a single error when no errors are present.
+	if len(me.errs) == 0 {
+		return nil
+	}
+
+	return me
+}
+
+// MultiError represents an error type that aggregates multiple errors.
+// It is used to accumulate and manage multiple errors, wrapping them into a single error instance.
+type MultiError struct {
+	errs   []error
+	Format ErrorFormat
+}
+
+// // ErrorOrNil returns an error if the MultiError instance contains any errors, or nil if it has none.
+// This method is useful for ensuring that a valid error value is returned after accumulating errors,
+// indicating whether errors are present or not.
+func (e *MultiError) ErrorOrNil() error {
+	if e == nil || len(e.errs) == 0 {
+		return nil
+	}
+
+	return e
+}
+
+// Error implements the error interface for MultiError.
+// It formats the accumulated errors into a single string representation.
+// If a custom ErrorFormat function is provided, it will be used;
+// otherwise, the default ErrorFormat (DefaultErrorFormat) will be applied.
+func (e *MultiError) Error() string {
+	if e.Format == nil {
+		e.Format = DefaultErrorFormat
+	}
+
+	return e.Format(e.errs)
+}
+
+// Is checks if any of the errors in the MultiError matches the target error.
+func (e *MultiError) Is(target error) bool {
+	for _, err := range e.errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// As finds the first error in the MultiError's errors that matches target,
+// and if one is found, sets target to that error value and returns true.
+// Otherwise, it returns false.
+func (e *MultiError) As(target any) bool {
+	for _, err := range e.errs {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Unwrap implements the unwrapping interface for MultiError.
+// It returns the slice of accumulated errors wrapped in the MultiError instance.
+// If there are no errors, it returns nil, indicating that e does not wrap any error.
+func (e *MultiError) Unwrap() []error {
+	if len(e.errs) == 0 {
+		return nil
+	}
+
+	return e.errs
+}

--- a/errors/multi_error_test.go
+++ b/errors/multi_error_test.go
@@ -1,0 +1,576 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppend(t *testing.T) {
+	var me *MultiError
+
+	tests := []struct {
+		name               string
+		e                  error
+		errs               []error
+		expectedMultiError *MultiError
+	}{
+		{
+			name:               "I",
+			e:                  nil,
+			errs:               nil,
+			expectedMultiError: nil,
+		},
+		{
+			name:               "II",
+			e:                  nil,
+			errs:               []error{},
+			expectedMultiError: nil,
+		},
+		{
+			name: "III",
+			e:    nil,
+			errs: []error{
+				new(barError),
+				new(bazError),
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name: "IV",
+			e:    nil,
+			errs: []error{
+				&MultiError{
+					errs: []error{
+						new(barError),
+						new(bazError),
+					},
+				},
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name: "V",
+			e:    new(fooError),
+			errs: nil,
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+		},
+		{
+			name: "VI",
+			e:    new(fooError),
+			errs: []error{},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+		},
+		{
+			name: "VII",
+			e:    new(fooError),
+			errs: []error{
+				new(barError),
+				new(bazError),
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name: "VIII",
+			e:    new(fooError),
+			errs: []error{
+				&MultiError{
+					errs: []error{
+						new(barError),
+						new(bazError),
+					},
+				},
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name:               "IX",
+			e:                  me,
+			errs:               nil,
+			expectedMultiError: nil,
+		},
+		{
+			name:               "X",
+			e:                  me,
+			errs:               []error{},
+			expectedMultiError: nil,
+		},
+		{
+			name: "XI",
+			e:    me,
+			errs: []error{
+				new(barError),
+				new(bazError),
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name: "XII",
+			e:    me,
+			errs: []error{
+				&MultiError{
+					errs: []error{
+						new(barError),
+						new(bazError),
+					},
+				},
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name:               "XIII",
+			e:                  &MultiError{},
+			errs:               nil,
+			expectedMultiError: nil,
+		},
+		{
+			name:               "XIV",
+			e:                  &MultiError{},
+			errs:               []error{},
+			expectedMultiError: nil,
+		},
+		{
+			name: "XV",
+			e:    &MultiError{},
+			errs: []error{
+				new(barError),
+				new(bazError),
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name: "XVI",
+			e:    &MultiError{},
+			errs: []error{
+				&MultiError{
+					errs: []error{
+						new(barError),
+						new(bazError),
+					},
+				},
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name: "XVII",
+			e: &MultiError{
+				errs: []error{},
+			},
+			errs:               nil,
+			expectedMultiError: nil,
+		},
+		{
+			name: "XVIII",
+			e: &MultiError{
+				errs: []error{},
+			},
+			errs:               []error{},
+			expectedMultiError: nil,
+		},
+		{
+			name: "XIX",
+			e: &MultiError{
+				errs: []error{},
+			},
+			errs: []error{
+				new(barError),
+				new(bazError),
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name: "XX",
+			e: &MultiError{
+				errs: []error{},
+			},
+			errs: []error{
+				&MultiError{
+					errs: []error{
+						new(barError),
+						new(bazError),
+					},
+				},
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name: "XXI",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+			errs: nil,
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+		},
+		{
+			name: "XXII",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+			errs: []error{},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+		},
+		{
+			name: "XXIII",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+			errs: []error{
+				new(barError),
+				new(bazError),
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+		{
+			name: "XXIV",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+			errs: []error{
+				&MultiError{
+					errs: []error{
+						new(barError),
+						new(bazError),
+					},
+				},
+			},
+			expectedMultiError: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+					new(bazError),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Append(tc.e, tc.errs...)
+			assert.Equal(t, tc.expectedMultiError, err)
+		})
+	}
+}
+
+func TestMultiError_ErrorOrNil(t *testing.T) {
+	tests := []struct {
+		name        string
+		e           *MultiError
+		expectError bool
+	}{
+
+		{
+			name: "Nil",
+			e: &MultiError{
+				errs: nil,
+			},
+			expectError: false,
+		},
+		{
+			name: "Zero",
+			e: &MultiError{
+				errs: []error{},
+			},
+			expectError: false,
+		},
+		{
+			name: "One",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Multiple",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+					new(bazError),
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.e.ErrorOrNil()
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMultiError_Error(t *testing.T) {
+	tests := []struct {
+		name          string
+		e             *MultiError
+		expectedError string
+	}{
+
+		{
+			name: "Nil",
+			e: &MultiError{
+				errs: nil,
+			},
+			expectedError: "",
+		},
+		{
+			name: "Zero",
+			e: &MultiError{
+				errs: []error{},
+			},
+			expectedError: "",
+		},
+		{
+			name: "One",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+			expectedError: "error on foo\n",
+		},
+		{
+			name: "Multiple",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+					new(bazError),
+				},
+			},
+			expectedError: "error on foo\nerror on bar\nerror on baz\nsomething failed\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.EqualError(t, tc.e, tc.expectedError)
+		})
+	}
+}
+
+func TestMultiError_Is(t *testing.T) {
+	tests := []struct {
+		name       string
+		e          *MultiError
+		target     error
+		expectedIs bool
+	}{
+		{
+			name: "False",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+				},
+			},
+			target:     &bazError{},
+			expectedIs: false,
+		},
+		{
+			name: "True",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+					new(bazError),
+				},
+			},
+			target:     &bazError{},
+			expectedIs: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			is := tc.e.Is(tc.target)
+			assert.Equal(t, tc.expectedIs, is)
+		})
+	}
+}
+
+func TestMultiError_As(t *testing.T) {
+	var bazErr *bazError
+
+	tests := []struct {
+		name       string
+		e          *MultiError
+		target     any
+		expectedAs bool
+	}{
+		{
+			name: "False",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+				},
+			},
+			target:     &bazErr,
+			expectedAs: false,
+		},
+		{
+			name: "True",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+					new(bazError),
+				},
+			},
+			target:     &bazErr,
+			expectedAs: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			as := tc.e.As(tc.target)
+			assert.Equal(t, tc.expectedAs, as)
+		})
+	}
+}
+
+func TestMultiError_Unwrap(t *testing.T) {
+	tests := []struct {
+		name           string
+		e              *MultiError
+		expectedErrors []error
+	}{
+		{
+			name:           "Nil",
+			e:              &MultiError{},
+			expectedErrors: nil,
+		},
+		{
+			name: "Zero",
+			e: &MultiError{
+				errs: []error{},
+			},
+			expectedErrors: nil,
+		},
+		{
+			name: "One",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+				},
+			},
+			expectedErrors: []error{
+				new(fooError),
+			},
+		},
+		{
+			name: "Multiple",
+			e: &MultiError{
+				errs: []error{
+					new(fooError),
+					new(barError),
+					new(bazError),
+				},
+			},
+			expectedErrors: []error{
+				new(fooError),
+				new(barError),
+				new(bazError),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.e.Unwrap()
+			assert.Equal(t, tc.expectedErrors, errs)
+		})
+	}
+}


### PR DESCRIPTION
Resolves #242 

## Description

  - [x] Add the new `errors` package.
  - [x] Implement `errors.MultiError` API
  - [x] Implement `errors.Group API`

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
