### PR TITLE
Add IsLL1 method to check LL(1) context-free grammars

### DIFF
--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -28,19 +28,19 @@ func ExampleAppend_withCustomFormat() {
 }
 
 func ExampleMultiError_ErrorOrNil() {
-	err := new(errors.MultiError)
-	err = err.ErrorOrNil()
+	me := new(errors.MultiError)
+	err := me.ErrorOrNil()
 
 	fmt.Println(err)
 }
 
 func ExampleMultiError_Unwrap() {
-	var err *errors.MultiError
-	err = errors.Append(err, fmt.Errorf("error on foo: %d", 1))
-	err = errors.Append(err, fmt.Errorf("error on bar: %d", 2))
-	err = errors.Append(err, fmt.Errorf("error on baz: %d", 3))
+	var me *errors.MultiError
+	me = errors.Append(me, fmt.Errorf("error on foo: %d", 1))
+	me = errors.Append(me, fmt.Errorf("error on bar: %d", 2))
+	me = errors.Append(me, fmt.Errorf("error on baz: %d", 3))
 
-	for _, err := range err.Unwrap() {
+	for _, err := range me.Unwrap() {
 		fmt.Println(err)
 	}
 }

--- a/errors/multi_error.go
+++ b/errors/multi_error.go
@@ -55,7 +55,7 @@ type MultiError struct {
 // // ErrorOrNil returns an error if the MultiError instance contains any errors, or nil if it has none.
 // This method is useful for ensuring that a valid error value is returned after accumulating errors,
 // indicating whether errors are present or not.
-func (e *MultiError) ErrorOrNil() *MultiError {
+func (e *MultiError) ErrorOrNil() error {
 	if e == nil || len(e.errs) == 0 {
 		return nil
 	}

--- a/errors/multi_error_test.go
+++ b/errors/multi_error_test.go
@@ -337,7 +337,7 @@ func TestMultiError_ErrorOrNil(t *testing.T) {
 	tests := []struct {
 		name               string
 		e                  *MultiError
-		expectedMultiError *MultiError
+		expectedMultiError error
 	}{
 
 		{

--- a/grammar/cfg_first.go
+++ b/grammar/cfg_first.go
@@ -1,8 +1,13 @@
 package grammar
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/moorara/algo/generic"
 	"github.com/moorara/algo/set"
-	. "github.com/moorara/algo/symboltable"
+	"github.com/moorara/algo/sort"
+	"github.com/moorara/algo/symboltable"
 )
 
 var eqTerminalsAndEmpty = func(lhs, rhs *TerminalsAndEmpty) bool {
@@ -27,6 +32,7 @@ type TerminalsAndEmpty struct {
 	IncludesEmpty bool
 }
 
+// newTerminalsAndEmpty creates a new TerminalsAndEmpty instance with the given set of terminals.
 func newTerminalsAndEmpty(terms ...Terminal) *TerminalsAndEmpty {
 	return &TerminalsAndEmpty{
 		Terminals:     set.New(eqTerminal, terms...),
@@ -34,16 +40,33 @@ func newTerminalsAndEmpty(terms ...Terminal) *TerminalsAndEmpty {
 	}
 }
 
+// String returns a string representation of the FIRST set.
+func (s TerminalsAndEmpty) String() string {
+	members := []string{}
+
+	for term := range s.Terminals.All() {
+		members = append(members, term.String())
+	}
+
+	if s.IncludesEmpty {
+		members = append(members, "ε")
+	}
+
+	sort.Quick(members, generic.NewCompareFunc[string]())
+
+	return fmt.Sprintf("{%s}", strings.Join(members, ", "))
+}
+
 // firstBySymbolTable is the type for a table that stores the FIRST set for each grammar symbol.
-type firstBySymbolTable SymbolTable[Symbol, *TerminalsAndEmpty]
+type firstBySymbolTable symboltable.SymbolTable[Symbol, *TerminalsAndEmpty]
 
 func newFirstBySymbolTable() firstBySymbolTable {
-	return NewQuadraticHashTable(hashSymbol, eqSymbol, eqTerminalsAndEmpty, HashOpts{})
+	return symboltable.NewQuadraticHashTable(hashSymbol, eqSymbol, eqTerminalsAndEmpty, symboltable.HashOpts{})
 }
 
 // firstByStringTable is the type for a table that stores the FIRST set for strings of grammar symbols.
-type firstByStringTable SymbolTable[String[Symbol], *TerminalsAndEmpty]
+type firstByStringTable symboltable.SymbolTable[String[Symbol], *TerminalsAndEmpty]
 
 func newFirstByStringTable() firstByStringTable {
-	return NewQuadraticHashTable(hashString, eqString, eqTerminalsAndEmpty, HashOpts{})
+	return symboltable.NewQuadraticHashTable(hashString, eqString, eqTerminalsAndEmpty, symboltable.HashOpts{})
 }

--- a/grammar/cfg_first_test.go
+++ b/grammar/cfg_first_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/moorara/algo/set"
 )
 
 func TestNewTerminalsAndEmpty(t *testing.T) {
@@ -23,6 +25,29 @@ func TestNewTerminalsAndEmpty(t *testing.T) {
 			assert.NotNil(t, f)
 			assert.True(t, f.Terminals.Contains(tc.terms...))
 			assert.False(t, f.IncludesEmpty)
+		})
+	}
+}
+
+func TestTerminalsAndEmpty(t *testing.T) {
+	tests := []struct {
+		name           string
+		set            TerminalsAndEmpty
+		expectedString string
+	}{
+		{
+			name: "OK",
+			set: TerminalsAndEmpty{
+				Terminals:     set.New(eqTerminal, "a", "b", "c", "d", "e", "f"),
+				IncludesEmpty: true,
+			},
+			expectedString: `{"a", "b", "c", "d", "e", "f", ε}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedString, tc.set.String())
 		})
 	}
 }

--- a/grammar/cfg_follow.go
+++ b/grammar/cfg_follow.go
@@ -1,8 +1,13 @@
 package grammar
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/moorara/algo/generic"
 	"github.com/moorara/algo/set"
-	. "github.com/moorara/algo/symboltable"
+	"github.com/moorara/algo/sort"
+	"github.com/moorara/algo/symboltable"
 )
 
 var eqTerminalsAndEndmarker = func(lhs, rhs *TerminalsAndEndmarker) bool {
@@ -28,6 +33,7 @@ type TerminalsAndEndmarker struct {
 	IncludesEndmarker bool
 }
 
+// newTerminalsAndEndmarker creates a new TerminalsAndEndmarker instance with the given set of terminals.
 func newTerminalsAndEndmarker(terms ...Terminal) *TerminalsAndEndmarker {
 	return &TerminalsAndEndmarker{
 		Terminals:         set.New(eqTerminal, terms...),
@@ -35,9 +41,26 @@ func newTerminalsAndEndmarker(terms ...Terminal) *TerminalsAndEndmarker {
 	}
 }
 
+// String returns a string representation of the FOLLOW set.
+func (s TerminalsAndEndmarker) String() string {
+	members := []string{}
+
+	for term := range s.Terminals.All() {
+		members = append(members, term.String())
+	}
+
+	if s.IncludesEndmarker {
+		members = append(members, "$")
+	}
+
+	sort.Quick(members, generic.NewCompareFunc[string]())
+
+	return fmt.Sprintf("{%s}", strings.Join(members, ", "))
+}
+
 // followTable is the type for a table that stores the FOLLOW set for each non-terminal.
-type followTable SymbolTable[NonTerminal, *TerminalsAndEndmarker]
+type followTable symboltable.SymbolTable[NonTerminal, *TerminalsAndEndmarker]
 
 func newFollowTable() followTable {
-	return NewQuadraticHashTable(hashNonTerminal, eqNonTerminal, eqTerminalsAndEndmarker, HashOpts{})
+	return symboltable.NewQuadraticHashTable(hashNonTerminal, eqNonTerminal, eqTerminalsAndEndmarker, symboltable.HashOpts{})
 }

--- a/grammar/cfg_follow_test.go
+++ b/grammar/cfg_follow_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/moorara/algo/set"
 )
 
 func TestNewTerminalsAndEndmarker(t *testing.T) {
@@ -23,6 +25,29 @@ func TestNewTerminalsAndEndmarker(t *testing.T) {
 			assert.NotNil(t, f)
 			assert.True(t, f.Terminals.Contains(tc.terms...))
 			assert.False(t, f.IncludesEndmarker)
+		})
+	}
+}
+
+func TestTerminalsAndEndmarker(t *testing.T) {
+	tests := []struct {
+		name           string
+		set            TerminalsAndEndmarker
+		expectedString string
+	}{
+		{
+			name: "OK",
+			set: TerminalsAndEndmarker{
+				Terminals:         set.New(eqTerminal, "a", "b", "c", "d", "e", "f"),
+				IncludesEndmarker: true,
+			},
+			expectedString: `{"a", "b", "c", "d", "e", "f", $}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedString, tc.set.String())
 		})
 	}
 }

--- a/grammar/cfg_test.go
+++ b/grammar/cfg_test.go
@@ -204,7 +204,7 @@ func TestCFG_Verify(t *testing.T) {
 				[]Production{},
 				"S",
 			),
-			expectedError: "start symbol S not in the set of non-terminal symbols\nno production rule for start symbol S",
+			expectedError: "start symbol S not in the set of non-terminal symbols\nno production rule for start symbol S\n",
 		},
 		{
 			name: "StartSymbolHasNoProduction",
@@ -214,7 +214,7 @@ func TestCFG_Verify(t *testing.T) {
 				[]Production{},
 				"S",
 			),
-			expectedError: "no production rule for start symbol S\nno production rule for non-terminal symbol S",
+			expectedError: "no production rule for start symbol S\nno production rule for non-terminal symbol S\n",
 		},
 		{
 			name: "NonTerminalHasNoProduction",
@@ -226,7 +226,7 @@ func TestCFG_Verify(t *testing.T) {
 				},
 				"S",
 			),
-			expectedError: "no production rule for non-terminal symbol A",
+			expectedError: "no production rule for non-terminal symbol A\n",
 		},
 		{
 			name: "ProductionHeadNotDeclared",
@@ -240,7 +240,7 @@ func TestCFG_Verify(t *testing.T) {
 				},
 				"S",
 			),
-			expectedError: "production head B not in the set of non-terminal symbols",
+			expectedError: "production head B not in the set of non-terminal symbols\n",
 		},
 		{
 			name: "TerminalNotDeclared",
@@ -254,7 +254,7 @@ func TestCFG_Verify(t *testing.T) {
 				},
 				"S",
 			),
-			expectedError: "terminal symbol \"a\" not in the set of terminal symbols",
+			expectedError: "terminal symbol \"a\" not in the set of terminal symbols\n",
 		},
 		{
 			name: "NonTerminalNotDeclared",
@@ -268,7 +268,7 @@ func TestCFG_Verify(t *testing.T) {
 				},
 				"S",
 			),
-			expectedError: "non-terminal symbol C not in the set of non-terminal symbols",
+			expectedError: "non-terminal symbol C not in the set of non-terminal symbols\n",
 		},
 		{
 			name: "Valid",
@@ -531,26 +531,106 @@ func TestCFG_Equals(t *testing.T) {
 
 func TestCFG_IsCNF(t *testing.T) {
 	tests := []struct {
-		name          string
-		g             CFG
-		expectedIsCNF bool
+		name                 string
+		g                    CFG
+		expectedErrorStrings []string
 	}{
 		{
-			name: "NotCNF",
-			g: NewCFG(
-				[]Terminal{"a", "b"},
-				[]NonTerminal{"S", "A", "B"},
-				[]Production{
-					{"S", String[Symbol]{NonTerminal("A"), NonTerminal("B")}}, // S → AB
-					{"S", ε}, // S → ε
-					{"A", String[Symbol]{Terminal("a"), NonTerminal("A")}}, // A → aA
-					{"A", String[Symbol]{Terminal("a")}},                   // A → a
-					{"B", String[Symbol]{Terminal("b"), NonTerminal("B")}}, // B → bB
-					{"B", String[Symbol]{Terminal("b")}},                   // B → b
-				},
-				"S",
-			),
-			expectedIsCNF: false,
+			name: "1st",
+			g:    CFGrammars[0],
+			expectedErrorStrings: []string{
+				`Production S → X Y X is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production X → "0" X is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production X → ε is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production Y → "1" Y is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production Y → ε is neither a binary rule, a terminal rule, nor S → ε`,
+			},
+		},
+		{
+			name: "2nd",
+			g:    CFGrammars[1],
+			expectedErrorStrings: []string{
+				`Production S → "a" S "b" S is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production S → "b" S "a" S is neither a binary rule, a terminal rule, nor S → ε`,
+			},
+		},
+		{
+			name: "3rd",
+			g:    CFGrammars[2],
+			expectedErrorStrings: []string{
+				`Production S → "a" B "a" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production S → A "b" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production A → ε is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production B → A is neither a binary rule, a terminal rule, nor S → ε`,
+			},
+		},
+		{
+			name: "4th",
+			g:    CFGrammars[3],
+			expectedErrorStrings: []string{
+				`Production S → A is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production A → B is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production B → C is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production C → D is neither a binary rule, a terminal rule, nor S → ε`,
+			},
+		},
+		{
+			name: "5th",
+			g:    CFGrammars[4],
+			expectedErrorStrings: []string{
+				`Production A → "a" A is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production B → "b" B is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production C → "c" C is neither a binary rule, a terminal rule, nor S → ε`,
+			},
+		},
+		{
+			name: "6th",
+			g:    CFGrammars[5],
+			expectedErrorStrings: []string{
+				`Production S → E is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production E → E "+" E is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production E → E "-" E is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production E → E "*" E is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production E → E "/" E is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production E → "(" E ")" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production E → "-" E is neither a binary rule, a terminal rule, nor S → ε`,
+			},
+		},
+		{
+			name: "7th",
+			g:    CFGrammars[6],
+			expectedErrorStrings: []string{
+				`Production S → E is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production E → E "+" T is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production E → E "-" T is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production E → T is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production T → T "*" F is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production T → T "/" F is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production T → F is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production F → "(" E ")" is neither a binary rule, a terminal rule, nor S → ε`,
+			},
+		},
+		{
+			name: "8th",
+			g:    CFGrammars[7],
+			expectedErrorStrings: []string{
+				`Production name → "GRAMMAR" "IDENT" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production decls → ε is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production decl → token is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production decl → rule is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production token → "TOKEN" "=" "STRING" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production token → "TOKEN" "=" "REGEX" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production rule → lhs "=" rhs is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production rule → lhs "=" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production rhs → nonterm is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production rhs → rhs "|" rhs is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production rhs → "(" rhs ")" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production rhs → "[" rhs "]" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production rhs → "{" rhs "}" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production rhs → "{{" rhs "}}" is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production lhs → nonterm is neither a binary rule, a terminal rule, nor S → ε`,
+				`Production rhs → term is neither a binary rule, a terminal rule, nor S → ε`,
+			},
 		},
 		{
 			name: "CNF",
@@ -569,75 +649,125 @@ func TestCFG_IsCNF(t *testing.T) {
 				},
 				"S",
 			),
-			expectedIsCNF: true,
+			expectedErrorStrings: nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.NoError(t, tc.g.Verify())
-			assert.Equal(t, tc.expectedIsCNF, tc.g.IsCNF())
+			err := tc.g.IsCNF()
+
+			if len(tc.expectedErrorStrings) == 0 {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				s := err.Error()
+				for _, expectedErrorString := range tc.expectedErrorStrings {
+					assert.Contains(t, s, expectedErrorString)
+				}
+			}
 		})
 	}
 }
 
 func TestCFG_IsLL1(t *testing.T) {
 	tests := []struct {
-		name          string
-		g             CFG
-		expectedIsLL1 bool
+		name                 string
+		g                    CFG
+		expectedErrorStrings []string
 	}{
 		{
-			name:          "1st",
-			g:             CFGrammars[0],
-			expectedIsLL1: false,
+			name: "1st",
+			g:    CFGrammars[0],
+			expectedErrorStrings: []string{
+				"ε is in FIRST(β), but FOLLOW(A) and FIRST(α) are not disjoint sets",
+			},
 		},
 		{
-			name:          "2nd",
-			g:             CFGrammars[1],
-			expectedIsLL1: false,
+			name: "2nd",
+			g:    CFGrammars[1],
+			expectedErrorStrings: []string{
+				"ε is in FIRST(β), but FOLLOW(A) and FIRST(α) are not disjoint sets",
+			},
 		},
 		{
-			name:          "3rd",
-			g:             CFGrammars[2],
-			expectedIsLL1: false,
+			name: "3rd",
+			g:    CFGrammars[2],
+			expectedErrorStrings: []string{
+				"FIRST(α) and FIRST(β) are not disjoint sets",
+				"ε is in FIRST(β), but FOLLOW(A) and FIRST(α) are not disjoint sets",
+			},
 		},
 		{
-			name:          "4th",
-			g:             CFGrammars[3],
-			expectedIsLL1: true,
+			name:                 "4th",
+			g:                    CFGrammars[3],
+			expectedErrorStrings: nil,
 		},
 		{
-			name:          "5th",
-			g:             CFGrammars[4],
-			expectedIsLL1: false,
+			name: "5th",
+			g:    CFGrammars[4],
+			expectedErrorStrings: []string{
+				"FIRST(α) and FIRST(β) are not disjoint sets",
+			},
 		},
 		{
-			name:          "6th",
-			g:             CFGrammars[5],
-			expectedIsLL1: false,
+			name: "6th",
+			g:    CFGrammars[5],
+			expectedErrorStrings: []string{
+				"FIRST(α) and FIRST(β) are not disjoint sets",
+			},
 		},
 		{
-			name:          "7th",
-			g:             CFGrammars[6],
-			expectedIsLL1: false,
+			name: "7th",
+			g:    CFGrammars[6],
+			expectedErrorStrings: []string{
+				"FIRST(α) and FIRST(β) are not disjoint sets",
+			},
 		},
 		{
-			name:          "8th",
-			g:             CFGrammars[7],
-			expectedIsLL1: false,
+			name: "8th",
+			g:    CFGrammars[7],
+			expectedErrorStrings: []string{
+				"FIRST(α) and FIRST(β) are not disjoint sets",
+				"ε is in FIRST(β), but FOLLOW(A) and FIRST(α) are not disjoint sets",
+			},
 		},
 		{
-			name:          "8th",
-			g:             CFGrammars[7],
-			expectedIsLL1: false,
+			name: "LL(1)",
+			g: NewCFG(
+				[]Terminal{"+", "*", "(", ")", "id"},
+				[]NonTerminal{"E", "E′", "T", "T′", "F"},
+				[]Production{
+					{"E", String[Symbol]{NonTerminal("T"), NonTerminal("E′")}},                 // E → T E′
+					{"E′", String[Symbol]{Terminal("+"), NonTerminal("T"), NonTerminal("E′")}}, // E′ → + T E′
+					{"E′", ε}, // E′ → ε
+					{"T", String[Symbol]{NonTerminal("F"), NonTerminal("T′")}},                 // T → F T′
+					{"T′", String[Symbol]{Terminal("*"), NonTerminal("F"), NonTerminal("T′")}}, // T′ → * F T′
+					{"T′", ε}, // T′ → ε
+					{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}}, // F → ( E )
+					{"F", String[Symbol]{Terminal("id")}},                                 // F → id
+				},
+				"E",
+			),
+			expectedErrorStrings: nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.NoError(t, tc.g.Verify())
-			assert.Equal(t, tc.expectedIsLL1, tc.g.IsLL1())
+			err := tc.g.IsLL1()
+
+			if len(tc.expectedErrorStrings) == 0 {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				s := err.Error()
+				for _, expectedErrorString := range tc.expectedErrorStrings {
+					assert.Contains(t, s, expectedErrorString)
+				}
+			}
 		})
 	}
 }

--- a/grammar/errors.go
+++ b/grammar/errors.go
@@ -1,0 +1,59 @@
+package grammar
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CNFError represents an error for a production rule in the form
+// A → α that does not conform to Chomsky Normal Form (CNF).
+type CNFError struct {
+	// The production rule not in Chomsky Normal Form (CNF).
+	P Production
+}
+
+// Error implements the error interface.
+// It returns a formatted string describing the error in detail.
+func (e *CNFError) Error() string {
+	b := new(strings.Builder)
+	fmt.Fprintf(b, "Production %s is neither a binary rule, a terminal rule, nor S → ε", e.P)
+	return b.String()
+}
+
+// LL1Error represents an error where two distinct production rules in the form
+// A → α | β violate LL(1) parsing requirements for a context-free grammar.
+type LL1Error struct {
+	// A brief description of the error, explaining the issue.
+	Description string
+	// The head of both productions.
+	A NonTerminal
+	// The bodies of productions.
+	Alpha, Beta String[Symbol]
+	// The FOLLOW set for the head of productions.
+	FOLLOWA *TerminalsAndEndmarker
+	// The FIRST sets for the bodies of production.
+	FIRSTα, FIRSTβ *TerminalsAndEmpty
+}
+
+// Error implements the error interface.
+// It returns a formatted string describing the error in detail.
+func (e *LL1Error) Error() string {
+	b := new(strings.Builder)
+
+	fmt.Fprintf(b, "%s:\n", e.Description)
+	fmt.Fprintf(b, "  %s → %s | %s\n", e.A, e.Alpha, e.Beta)
+
+	if e.FOLLOWA != nil {
+		fmt.Fprintf(b, "    FOLLOW(%s): %s\n", e.A, e.FOLLOWA)
+	}
+
+	if e.FIRSTα != nil {
+		fmt.Fprintf(b, "    FIRST(%s): %s\n", e.Alpha, e.FIRSTα)
+	}
+
+	if e.FIRSTβ != nil {
+		fmt.Fprintf(b, "    FIRST(%s): %s\n", e.Beta, e.FIRSTβ)
+	}
+
+	return b.String()
+}

--- a/grammar/errors_test.go
+++ b/grammar/errors_test.go
@@ -1,0 +1,63 @@
+package grammar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moorara/algo/set"
+)
+
+func TestCNFError(t *testing.T) {
+	tests := []struct {
+		name          string
+		e             *CNFError
+		expectedError string
+	}{
+		{
+			name: "OK",
+			e: &CNFError{
+				P: Production{"rule", String[Symbol]{NonTerminal("lhs"), Terminal("="), NonTerminal("rhs")}},
+			},
+			expectedError: `Production rule → lhs "=" rhs is neither a binary rule, a terminal rule, nor S → ε`,
+		},
+	}
+
+	for _, tc := range tests {
+		assert.EqualError(t, tc.e, tc.expectedError)
+	}
+}
+
+func TestLL1Error(t *testing.T) {
+	tests := []struct {
+		name          string
+		e             *LL1Error
+		expectedError string
+	}{
+		{
+			name: "OK",
+			e: &LL1Error{
+				Description: "ε is in FIRST(β), but FOLLOW(A) and FIRST(α) are not disjoint sets",
+				A:           NonTerminal("decls"),
+				Alpha:       String[Symbol]{NonTerminal("decls"), NonTerminal("decl")},
+				Beta:        ε,
+				FOLLOWA: &TerminalsAndEndmarker{
+					Terminals:         set.New(eqTerminal, "IDENT", "TOKEN"),
+					IncludesEndmarker: true,
+				},
+				FIRSTα: &TerminalsAndEmpty{
+					Terminals: set.New(eqTerminal, "IDENT", "TOKEN"),
+				},
+				FIRSTβ: &TerminalsAndEmpty{
+					Terminals:     set.New(eqTerminal),
+					IncludesEmpty: true,
+				},
+			},
+			expectedError: "ε is in FIRST(β), but FOLLOW(A) and FIRST(α) are not disjoint sets:\n  decls → decls decl | ε\n    FOLLOW(decls): {\"IDENT\", \"TOKEN\", $}\n    FIRST(decls decl): {\"IDENT\", \"TOKEN\"}\n    FIRST(ε): {ε}\n",
+		},
+	}
+
+	for _, tc := range tests {
+		assert.EqualError(t, tc.e, tc.expectedError)
+	}
+}

--- a/grammar/production.go
+++ b/grammar/production.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"iter"
 
-	. "github.com/moorara/algo/generic"
+	"github.com/moorara/algo/generic"
 	"github.com/moorara/algo/set"
 	"github.com/moorara/algo/sort"
-	. "github.com/moorara/algo/symboltable"
+	"github.com/moorara/algo/symboltable"
 )
 
 var (
@@ -80,8 +80,8 @@ func (p Production) IsCNF() (bool, bool) {
 // Productions is the interface for the set of production rules of a context-free grammar.
 type Productions interface {
 	fmt.Stringer
-	Cloner[Productions]
-	Equaler[Productions]
+	generic.Cloner[Productions]
+	generic.Equaler[Productions]
 
 	Add(...Production)
 	Remove(...Production)
@@ -90,19 +90,19 @@ type Productions interface {
 	Order(NonTerminal) []Production
 	All() iter.Seq[Production]
 	AllByHead() iter.Seq2[NonTerminal, set.Set[Production]]
-	AnyMatch(Predicate1[Production]) bool
-	AllMatch(Predicate1[Production]) bool
+	AnyMatch(generic.Predicate1[Production]) bool
+	AllMatch(generic.Predicate1[Production]) bool
 }
 
 // productions implements the Productions interface.
 type productions struct {
-	table SymbolTable[NonTerminal, set.Set[Production]]
+	table symboltable.SymbolTable[NonTerminal, set.Set[Production]]
 }
 
 // NewProductions creates a new instance of the Productions.
 func NewProductions() Productions {
 	return &productions{
-		table: NewQuadraticHashTable(hashNonTerminal, eqNonTerminal, eqProductionSet, HashOpts{}),
+		table: symboltable.NewQuadraticHashTable(hashNonTerminal, eqNonTerminal, eqProductionSet, symboltable.HashOpts{}),
 	}
 }
 
@@ -191,7 +191,7 @@ func (p *productions) Get(head NonTerminal) set.Set[Production] {
 // The goal of this function is to ensure a consistent and deterministic order for any given set of production rules.
 func (p *productions) Order(head NonTerminal) []Production {
 	// Collect all production rules into a slice from the set iterator.
-	prods := Collect1(p.Get(head).All())
+	prods := generic.Collect1(p.Get(head).All())
 
 	// Sort the productions using a custom comparison function.
 	sort.Quick[Production](prods, func(lhs, rhs Production) int {
@@ -247,7 +247,7 @@ func (p *productions) AllByHead() iter.Seq2[NonTerminal, set.Set[Production]] {
 }
 
 // AnyMatch returns true if at least one production rule satisfies the provided predicate.
-func (p *productions) AnyMatch(pred Predicate1[Production]) bool {
+func (p *productions) AnyMatch(pred generic.Predicate1[Production]) bool {
 	for q := range p.All() {
 		if pred(q) {
 			return true
@@ -259,7 +259,7 @@ func (p *productions) AnyMatch(pred Predicate1[Production]) bool {
 
 // AllMatch returns true if all production rules satisfy the provided predicate.
 // If the set of production rules is empty, it returns true.
-func (p *productions) AllMatch(pred Predicate1[Production]) bool {
+func (p *productions) AllMatch(pred generic.Predicate1[Production]) bool {
 	for q := range p.All() {
 		if !pred(q) {
 			return false
@@ -271,7 +271,7 @@ func (p *productions) AllMatch(pred Predicate1[Production]) bool {
 
 // SelectMatch selects a subset of production rules that satisfy the given predicate.
 // It returns a new set of production rules containing the matching productions, of the same type as the original set of production rules.
-func (p *productions) SelectMatch(pred Predicate1[Production]) Productions {
+func (p *productions) SelectMatch(pred generic.Predicate1[Production]) Productions {
 	newP := NewProductions()
 
 	for q := range p.All() {

--- a/grammar/production_test.go
+++ b/grammar/production_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/moorara/algo/generic"
+	"github.com/moorara/algo/generic"
 	"github.com/moorara/algo/set"
 )
 
@@ -656,7 +656,7 @@ func TestProductions_AnyMatch(t *testing.T) {
 	tests := []struct {
 		name             string
 		p                *productions
-		pred             Predicate1[Production]
+		pred             generic.Predicate1[Production]
 		expectedAnyMatch bool
 	}{
 		{
@@ -687,7 +687,7 @@ func TestProductions_AllMatch(t *testing.T) {
 	tests := []struct {
 		name             string
 		p                *productions
-		pred             Predicate1[Production]
+		pred             generic.Predicate1[Production]
 		expectedAllMatch bool
 	}{
 		{
@@ -723,7 +723,7 @@ func TestProductions_SelectMatch(t *testing.T) {
 	tests := []struct {
 		name                string
 		p                   *productions
-		pred                Predicate1[Production]
+		pred                generic.Predicate1[Production]
 		expectedSelectMatch *productions
 	}{
 		{

--- a/grammar/string.go
+++ b/grammar/string.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"strings"
 
-	. "github.com/moorara/algo/generic"
-	. "github.com/moorara/algo/hash"
+	"github.com/moorara/algo/generic"
+	"github.com/moorara/algo/hash"
 	"github.com/moorara/algo/set"
 )
 
@@ -81,7 +81,7 @@ func (s String[T]) HasSuffix(prefix String[T]) bool {
 }
 
 // AnyMatch returns true if at least one symbol satisfies the provided predicate.
-func (s String[T]) AnyMatch(pred Predicate1[T]) bool {
+func (s String[T]) AnyMatch(pred generic.Predicate1[T]) bool {
 	for _, sym := range s {
 		if pred(sym) {
 			return true
@@ -180,7 +180,7 @@ func WriteString(w io.Writer, s String[Symbol]) (n int, err error) {
 }
 
 // hashFuncForString creates a HashFunc for hashing strings of symbols.
-func hashFuncForString() HashFunc[String[Symbol]] {
+func hashFuncForString() hash.HashFunc[String[Symbol]] {
 	h := fnv.New64()
 
 	return func(s String[Symbol]) uint64 {

--- a/grammar/string_test.go
+++ b/grammar/string_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/moorara/algo/generic"
+	"github.com/moorara/algo/generic"
 )
 
 func TestString(t *testing.T) {
@@ -22,7 +22,7 @@ func TestString(t *testing.T) {
 		expectedHasPrefix      bool
 		suffix                 String[Symbol]
 		expectedHasSuffix      bool
-		anyMatch               Predicate1[Symbol]
+		anyMatch               generic.Predicate1[Symbol]
 		expectedAnyMatch       bool
 		append                 []Symbol
 		expectedAppend         String[Symbol]

--- a/grammar/symbol.go
+++ b/grammar/symbol.go
@@ -5,8 +5,8 @@ import (
 	"hash/fnv"
 	"io"
 
-	. "github.com/moorara/algo/generic"
-	. "github.com/moorara/algo/hash"
+	"github.com/moorara/algo/generic"
+	"github.com/moorara/algo/hash"
 )
 
 // The endmarker is a special symbol that is used to indicate the end of a string.
@@ -25,12 +25,12 @@ var (
 		return lhs.Equals(rhs)
 	}
 
-	eqTerminal  = NewEqualFunc[Terminal]()
-	cmpTerminal = NewCompareFunc[Terminal]()
+	eqTerminal  = generic.NewEqualFunc[Terminal]()
+	cmpTerminal = generic.NewCompareFunc[Terminal]()
 
-	eqNonTerminal   = NewEqualFunc[NonTerminal]()
-	cmpNonTerminal  = NewCompareFunc[NonTerminal]()
-	hashNonTerminal = HashFuncForString[NonTerminal](nil)
+	eqNonTerminal   = generic.NewEqualFunc[NonTerminal]()
+	cmpNonTerminal  = generic.NewCompareFunc[NonTerminal]()
+	hashNonTerminal = hash.HashFuncForString[NonTerminal](nil)
 )
 
 // Symbol represents a grammar symbol (terminal or non-terminal).
@@ -49,7 +49,7 @@ func WriteSymbol(w io.Writer, s Symbol) (n int, err error) {
 }
 
 // hashFuncForSymbol creates a HashFunc for hashing symbols.
-func hashFuncForSymbol() HashFunc[Symbol] {
+func hashFuncForSymbol() hash.HashFunc[Symbol] {
 	h := fnv.New64()
 
 	return func(s Symbol) uint64 {


### PR DESCRIPTION
## Description

  - [x] Add `IsLL1` to `CFG`
  - [x] Implement `CNFError` and `LL1Errors`

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
