### PR TITLE
Predictive parsing table

### DIFF
--- a/grammar/cfg_first.go
+++ b/grammar/cfg_first.go
@@ -61,12 +61,22 @@ func (s TerminalsAndEmpty) String() string {
 type firstBySymbolTable symboltable.SymbolTable[Symbol, *TerminalsAndEmpty]
 
 func newFirstBySymbolTable() firstBySymbolTable {
-	return symboltable.NewQuadraticHashTable(hashSymbol, eqSymbol, eqTerminalsAndEmpty, symboltable.HashOpts{})
+	return symboltable.NewQuadraticHashTable(
+		hashSymbol,
+		eqSymbol,
+		eqTerminalsAndEmpty,
+		symboltable.HashOpts{},
+	)
 }
 
 // firstByStringTable is the type for a table that stores the FIRST set for strings of grammar symbols.
 type firstByStringTable symboltable.SymbolTable[String[Symbol], *TerminalsAndEmpty]
 
 func newFirstByStringTable() firstByStringTable {
-	return symboltable.NewQuadraticHashTable(hashString, eqString, eqTerminalsAndEmpty, symboltable.HashOpts{})
+	return symboltable.NewQuadraticHashTable(
+		hashString,
+		eqString,
+		eqTerminalsAndEmpty,
+		symboltable.HashOpts{},
+	)
 }

--- a/grammar/cfg_follow.go
+++ b/grammar/cfg_follow.go
@@ -50,7 +50,7 @@ func (s TerminalsAndEndmarker) String() string {
 	}
 
 	if s.IncludesEndmarker {
-		members = append(members, "$")
+		members = append(members, endmarker.String())
 	}
 
 	sort.Quick(members, generic.NewCompareFunc[string]())
@@ -62,5 +62,10 @@ func (s TerminalsAndEndmarker) String() string {
 type followTable symboltable.SymbolTable[NonTerminal, *TerminalsAndEndmarker]
 
 func newFollowTable() followTable {
-	return symboltable.NewQuadraticHashTable(hashNonTerminal, eqNonTerminal, eqTerminalsAndEndmarker, symboltable.HashOpts{})
+	return symboltable.NewQuadraticHashTable(
+		hashNonTerminal,
+		eqNonTerminal,
+		eqTerminalsAndEndmarker,
+		symboltable.HashOpts{},
+	)
 }

--- a/grammar/errors.go
+++ b/grammar/errors.go
@@ -3,12 +3,13 @@ package grammar
 import (
 	"fmt"
 	"strings"
+
+	"github.com/moorara/algo/set"
 )
 
 // CNFError represents an error for a production rule in the form
 // A → α that does not conform to Chomsky Normal Form (CNF).
 type CNFError struct {
-	// The production rule not in Chomsky Normal Form (CNF).
 	P Production
 }
 
@@ -16,22 +17,17 @@ type CNFError struct {
 // It returns a formatted string describing the error in detail.
 func (e *CNFError) Error() string {
 	b := new(strings.Builder)
-	fmt.Fprintf(b, "Production %s is neither a binary rule, a terminal rule, nor S → ε", e.P)
+	fmt.Fprintf(b, "production %s is neither a binary rule, a terminal rule, nor S → ε", e.P)
 	return b.String()
 }
 
 // LL1Error represents an error where two distinct production rules in the form
 // A → α | β violate LL(1) parsing requirements for a context-free grammar.
 type LL1Error struct {
-	// A brief description of the error, explaining the issue.
-	Description string
-	// The head of both productions.
-	A NonTerminal
-	// The bodies of productions.
-	Alpha, Beta String[Symbol]
-	// The FOLLOW set for the head of productions.
-	FOLLOWA *TerminalsAndEndmarker
-	// The FIRST sets for the bodies of production.
+	Description    string
+	A              NonTerminal
+	Alpha, Beta    String[Symbol]
+	FOLLOWA        *TerminalsAndEndmarker
 	FIRSTα, FIRSTβ *TerminalsAndEmpty
 }
 
@@ -53,6 +49,27 @@ func (e *LL1Error) Error() string {
 
 	if e.FIRSTβ != nil {
 		fmt.Fprintf(b, "    FIRST(%s): %s\n", e.Beta, e.FIRSTβ)
+	}
+
+	return b.String()
+}
+
+// ParsingTableError represents an error encountered when constructing a predictive parsing table.
+// This error occurs due to the presence of left recursion or ambiguity in the grammar.
+type ParsingTableError struct {
+	NonTerminal NonTerminal
+	Terminal    Terminal
+	Productions set.Set[Production]
+}
+
+// Error implements the error interface.
+// It returns a formatted string describing the error in detail.
+func (e *ParsingTableError) Error() string {
+	b := new(strings.Builder)
+
+	fmt.Fprintf(b, "multiple productions in parsing table at M[%s, %s]:\n", e.NonTerminal, e.Terminal)
+	for _, p := range orderProductionSet(e.Productions) {
+		fmt.Fprintf(b, "  %s\n", p)
 	}
 
 	return b.String()

--- a/grammar/errors_test.go
+++ b/grammar/errors_test.go
@@ -19,7 +19,7 @@ func TestCNFError(t *testing.T) {
 			e: &CNFError{
 				P: Production{"rule", String[Symbol]{NonTerminal("lhs"), Terminal("="), NonTerminal("rhs")}},
 			},
-			expectedError: `Production rule → lhs "=" rhs is neither a binary rule, a terminal rule, nor S → ε`,
+			expectedError: `production rule → lhs "=" rhs is neither a binary rule, a terminal rule, nor S → ε`,
 		},
 	}
 
@@ -54,6 +54,31 @@ func TestLL1Error(t *testing.T) {
 				},
 			},
 			expectedError: "ε is in FIRST(β), but FOLLOW(A) and FIRST(α) are not disjoint sets:\n  decls → decls decl | ε\n    FOLLOW(decls): {\"IDENT\", \"TOKEN\", $}\n    FIRST(decls decl): {\"IDENT\", \"TOKEN\"}\n    FIRST(ε): {ε}\n",
+		},
+	}
+
+	for _, tc := range tests {
+		assert.EqualError(t, tc.e, tc.expectedError)
+	}
+}
+
+func TestParsingTableError(t *testing.T) {
+	tests := []struct {
+		name          string
+		e             *ParsingTableError
+		expectedError string
+	}{
+		{
+			name: "OK",
+			e: &ParsingTableError{
+				NonTerminal: NonTerminal("decls"),
+				Terminal:    Terminal("IDENT"),
+				Productions: set.New(eqProduction,
+					Production{"decls", String[Symbol]{NonTerminal("decls"), NonTerminal("decl")}},
+					Production{"decls", ε},
+				),
+			},
+			expectedError: "multiple productions in parsing table at M[decls, \"IDENT\"]:\n  decls → decls decl\n  decls → ε\n",
 		},
 	}
 

--- a/grammar/parsing_table.go
+++ b/grammar/parsing_table.go
@@ -1,0 +1,290 @@
+package grammar
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/moorara/algo/errors"
+	"github.com/moorara/algo/generic"
+	"github.com/moorara/algo/set"
+	"github.com/moorara/algo/symboltable"
+)
+
+// ParsingTable represents the interface for a predictive parsing table used for LL(1) context-free grammars.
+type ParsingTable interface {
+	fmt.Stringer
+	generic.Equaler[ParsingTable]
+
+	Add(NonTerminal, Terminal, Production)
+	Get(NonTerminal, Terminal) set.Set[Production]
+	CheckErrors() error
+}
+
+// parsingTable implements the ParsingTable interface.
+type parsingTable struct {
+	nonTerminals []NonTerminal
+	terminals    []Terminal
+	table        symboltable.SymbolTable[NonTerminal, symboltable.SymbolTable[Terminal, set.Set[Production]]]
+}
+
+// NewParsingTable creates a new instance of the ParsingTable.
+func NewParsingTable(terminals []Terminal, nonTerminals []NonTerminal) ParsingTable {
+	t := &parsingTable{
+		nonTerminals: nonTerminals,
+		terminals:    append(terminals, endmarker),
+		table: symboltable.NewQuadraticHashTable(
+			hashNonTerminal,
+			eqNonTerminal,
+			func(lhs, rhs symboltable.SymbolTable[Terminal, set.Set[Production]]) bool {
+				return lhs.Equals(rhs)
+			},
+			symboltable.HashOpts{},
+		),
+	}
+
+	// Populate the parsing table with empty sets.
+	for _, A := range t.nonTerminals {
+		ARow := symboltable.NewQuadraticHashTable(
+			hashTerminal,
+			eqTerminal,
+			eqProductionSet,
+			symboltable.HashOpts{},
+		)
+
+		for _, a := range t.terminals {
+			ARow.Put(a, set.New(eqProduction))
+		}
+
+		t.table.Put(A, ARow)
+	}
+
+	return t
+}
+
+// String returns a string representation of the parsing table.
+func (t *parsingTable) String() string {
+	return newParsingTablePrinter(t).String()
+}
+
+// Equals determines whether or not two parsing tables are the same.
+func (t *parsingTable) Equals(rhs ParsingTable) bool {
+	u, ok := rhs.(*parsingTable)
+	return ok && t.table.Equals(u.table)
+}
+
+// Add adds a new entry to the parsing table.
+// Multiple productions can be added for the same non-terminal A and terminal a.
+func (t *parsingTable) Add(A NonTerminal, a Terminal, prod Production) {
+	// The parsing table is pre-populated with empty sets.
+	ARow, _ := t.table.Get(A)
+	prods, _ := ARow.Get(a)
+	prods.Add(prod)
+}
+
+// Get looks up an entry in the parsing table.
+func (t *parsingTable) Get(A NonTerminal, a Terminal) set.Set[Production] {
+	// The parsing table is pre-populated with empty sets.
+	ARow, _ := t.table.Get(A)
+	prods, _ := ARow.Get(a)
+	return prods
+}
+
+// CheckErrors checks for conflicts in the parsing table.
+// If there are multiple productions for at least one combination of non-terminal A and terminal a,
+// the method returns an error containing details about the conflicting productions.
+// If no conflicts are found, it returns nil.
+func (t *parsingTable) CheckErrors() error {
+	var err = &errors.MultiError{
+		Format: errors.BulletErrorFormat,
+	}
+
+	for _, A := range t.nonTerminals {
+		for _, a := range t.terminals {
+			if prods := t.Get(A, a); prods.Size() > 1 {
+				err = errors.Append(err, &ParsingTableError{
+					NonTerminal: A,
+					Terminal:    a,
+					Productions: prods,
+				})
+			}
+		}
+	}
+
+	return err.ErrorOrNil()
+}
+
+// parsingTablePrinter is used for building a string representation of a parsing table.
+type parsingTablePrinter struct {
+	t     *parsingTable
+	b     *strings.Builder
+	cLens []int
+	tLen  int
+}
+
+func newParsingTablePrinter(t *parsingTable) *parsingTablePrinter {
+	return &parsingTablePrinter{
+		t: t,
+		b: new(strings.Builder),
+	}
+}
+
+func (p *parsingTablePrinter) String() string {
+	p.b = new(strings.Builder)
+	rowTitle, colTitle := "Non-Terminal", "Terminal"
+
+	// Calculate the maximum length of each column and the total length of the table.
+	p.calculateColumnLengths(rowTitle)
+
+	p.printTopLine()               // ┌──────────────┬───────────────┐
+	p.printCell01(colTitle)        // │              │   Terminal    │
+	p.printSecondLine()            // ├──────────────┼───┬────┬───┬──┤
+	p.printCell(0, rowTitle, true) // │ Non-Terminal │ ...
+
+	//  ... a │ b │ c │ d │
+	for i := 1; i < len(p.cLens); i++ {
+		a := p.t.terminals[i-1]
+		p.printCell(i, a.String(), false)
+	}
+
+	p.b.WriteRune('\n')
+
+	for _, A := range p.t.nonTerminals {
+		p.printMiddleLine()              // ├──────────────┼───────────────┤
+		p.printCell(0, A.String(), true) // │      A       │ ...
+
+		//  ... P1 │ P2 │ P3 │ P4 │
+		for i := 1; i < len(p.cLens); i++ {
+			a := p.t.terminals[i-1]
+			s := p.flattenProductions(A, a)
+			p.printCell(i, s, false)
+		}
+
+		p.b.WriteRune('\n')
+	}
+
+	p.printBottomLine() // └──────────────┴───────────────┘
+
+	return p.b.String()
+}
+
+func (p *parsingTablePrinter) flattenProductions(A NonTerminal, a Terminal) string {
+	prods := orderProductionSet(p.t.Get(A, a))
+	if len(prods) == 0 {
+		return ""
+	}
+
+	ss := make([]string, len(prods))
+	for i, p := range prods {
+		ss[i] = p.String()
+	}
+
+	return strings.Join(ss, " ┆ ")
+}
+
+func (p *parsingTablePrinter) calculateColumnLengths(header0 string) {
+	p.cLens = make([]int, len(p.t.terminals)+1)
+
+	// Find the maximum length of the first column, which belongs to non-terminals.
+	p.cLens[0] = utf8.RuneCountInString(header0)
+	for _, A := range p.t.nonTerminals {
+		if l := utf8.RuneCountInString(A.String()); l > p.cLens[0] {
+			p.cLens[0] = l
+		}
+	}
+
+	// Find the maximum length of each terminal column.
+	for i, a := range p.t.terminals {
+		p.cLens[i+1] = utf8.RuneCountInString(a.String())
+		for _, A := range p.t.nonTerminals {
+			s := p.flattenProductions(A, a)
+			if l := utf8.RuneCountInString(s); l > p.cLens[i+1] {
+				p.cLens[i+1] = l
+			}
+		}
+	}
+
+	// Add padding to each column.
+	for i := range p.cLens {
+		p.cLens[i] += 2
+	}
+
+	// Calculate the total length of the table.
+	p.tLen = len(p.cLens) + 1
+	for _, l := range p.cLens {
+		p.tLen += l
+	}
+}
+
+func (p *parsingTablePrinter) printCell01(header1 string) {
+	len1 := p.tLen - p.cLens[0] - 3
+	pad1 := len1 - len(header1)
+	lpad1 := pad1 / 2
+	rpad1 := pad1 - lpad1
+	p.b.WriteRune('│')
+	p.b.WriteString(strings.Repeat(" ", p.cLens[0]))
+	p.b.WriteRune('│')
+	p.b.WriteString(strings.Repeat(" ", lpad1))
+	p.b.WriteString(header1)
+	p.b.WriteString(strings.Repeat(" ", rpad1))
+	p.b.WriteRune('│')
+	p.b.WriteRune('\n')
+}
+
+func (p *parsingTablePrinter) printCell(col int, s string, isFirstCell bool) {
+	if isFirstCell {
+		p.b.WriteRune('│')
+	}
+
+	pad0 := p.cLens[col] - utf8.RuneCountInString(s)
+	lpad0 := pad0 / 2
+	rpad0 := pad0 - lpad0
+	p.b.WriteString(strings.Repeat(" ", lpad0))
+	p.b.WriteString(s)
+	p.b.WriteString(strings.Repeat(" ", rpad0))
+	p.b.WriteRune('│')
+}
+
+func (p *parsingTablePrinter) printTopLine() {
+	p.b.WriteRune('┌')
+	p.b.WriteString(strings.Repeat("─", p.cLens[0]))
+	p.b.WriteRune('┬')
+	p.b.WriteString(strings.Repeat("─", p.tLen-p.cLens[0]-3))
+	p.b.WriteRune('┐')
+	p.b.WriteRune('\n')
+}
+
+func (p *parsingTablePrinter) printSecondLine() {
+	p.b.WriteRune('├')
+	p.b.WriteString(strings.Repeat("─", p.cLens[0]))
+	p.b.WriteRune('┼')
+	p.b.WriteString(strings.Repeat("─", p.cLens[1]))
+	for i := 2; i < len(p.cLens); i++ {
+		p.b.WriteRune('┬')
+		p.b.WriteString(strings.Repeat("─", p.cLens[i]))
+	}
+	p.b.WriteRune('┤')
+	p.b.WriteRune('\n')
+}
+
+func (p *parsingTablePrinter) printMiddleLine() {
+	p.b.WriteRune('├')
+	p.b.WriteString(strings.Repeat("─", p.cLens[0]))
+	for i := 1; i < len(p.cLens); i++ {
+		p.b.WriteRune('┼')
+		p.b.WriteString(strings.Repeat("─", p.cLens[i]))
+	}
+	p.b.WriteRune('┤')
+	p.b.WriteRune('\n')
+}
+
+func (p *parsingTablePrinter) printBottomLine() {
+	p.b.WriteRune('└')
+	p.b.WriteString(strings.Repeat("─", p.cLens[0]))
+	for i := 1; i < len(p.cLens); i++ {
+		p.b.WriteRune('┴')
+		p.b.WriteString(strings.Repeat("─", p.cLens[i]))
+	}
+	p.b.WriteRune('┘')
+	p.b.WriteRune('\n')
+}

--- a/grammar/parsing_table_test.go
+++ b/grammar/parsing_table_test.go
@@ -1,0 +1,245 @@
+package grammar
+
+import (
+	"testing"
+
+	"github.com/moorara/algo/set"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestParsingTables() []*parsingTable {
+	pt0 := NewParsingTable(
+		[]Terminal{"+", "*", "(", ")", "id"},
+		[]NonTerminal{"E", "E′", "T", "T′", "F"},
+	).(*parsingTable)
+
+	pt0.Add("E", "id", Production{"E", String[Symbol]{NonTerminal("T"), NonTerminal("E′")}})
+	pt0.Add("E", "(", Production{"E", String[Symbol]{NonTerminal("T"), NonTerminal("E′")}})
+	pt0.Add("E′", "+", Production{"E′", String[Symbol]{Terminal("+"), NonTerminal("T"), NonTerminal("E′")}})
+	pt0.Add("E′", ")", Production{"E′", ε})
+	pt0.Add("E′", endmarker, Production{"E′", ε})
+	pt0.Add("T", "id", Production{"T", String[Symbol]{NonTerminal("F"), NonTerminal("T′")}})
+	pt0.Add("T", "(", Production{"T", String[Symbol]{NonTerminal("F"), NonTerminal("T′")}})
+	pt0.Add("T′", "+", Production{"T′", ε})
+	pt0.Add("T′", "*", Production{"T′", String[Symbol]{Terminal("*"), NonTerminal("F"), NonTerminal("T′")}})
+	pt0.Add("T′", ")", Production{"T′", ε})
+	pt0.Add("T′", endmarker, Production{"T′", ε})
+	pt0.Add("F", "id", Production{"F", String[Symbol]{Terminal("id")}})
+	pt0.Add("F", "(", Production{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}})
+
+	pt1 := NewParsingTable(
+		[]Terminal{"a", "b", "e", "i", "t"},
+		[]NonTerminal{"S", "S′", "E"},
+	).(*parsingTable)
+
+	pt1.Add("S", "a", Production{"S", String[Symbol]{Terminal("a")}})
+	pt1.Add("S", "i", Production{"S", String[Symbol]{Terminal("i"), NonTerminal("E"), Terminal("t"), NonTerminal("S"), NonTerminal("S′")}})
+	pt1.Add("S′", "e", Production{"S′", ε})
+	pt1.Add("S′", "e", Production{"S′", String[Symbol]{Terminal("e"), NonTerminal("S")}})
+	pt1.Add("S′", endmarker, Production{"S′", ε})
+	pt1.Add("E", "b", Production{"E", String[Symbol]{Terminal("b")}})
+
+	pt2 := NewParsingTable(
+		[]Terminal{"+", "*", "(", ")", "id"},
+		[]NonTerminal{"E", "T", "F"},
+	).(*parsingTable)
+
+	return []*parsingTable{pt0, pt1, pt2}
+}
+
+func TestNewParsingTable(t *testing.T) {
+	tests := []struct {
+		name                 string
+		terminals            []Terminal
+		nonTerminals         []NonTerminal
+		expectedTerminals    []Terminal
+		expectedNonTerminals []NonTerminal
+	}{
+		{
+			name:                 "OK",
+			terminals:            []Terminal{"+", "*", "(", ")", "id"},
+			nonTerminals:         []NonTerminal{"E", "E′", "T", "T′", "F"},
+			expectedTerminals:    []Terminal{"+", "*", "(", ")", "id", endmarker},
+			expectedNonTerminals: []NonTerminal{"E", "E′", "T", "T′", "F"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pt := NewParsingTable(tc.terminals, tc.nonTerminals).(*parsingTable)
+
+			assert.NotNil(t, pt)
+			assert.Equal(t, tc.expectedTerminals, pt.terminals)
+			assert.Equal(t, tc.expectedNonTerminals, pt.nonTerminals)
+		})
+	}
+}
+
+func TestParsingTable_String(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name               string
+		pt                 *parsingTable
+		expectedSubstrings []string
+	}{
+		{
+			name: "OK",
+			pt:   pt[0],
+			expectedSubstrings: []string{
+				`┌──────────────┬────────────────────────────────────────────────────────────────────────────┐`,
+				`│              │                                  Terminal                                  │`,
+				`├──────────────┼───────────────┬───────────────┬───────────────┬────────┬──────────┬────────┤`,
+				`│ Non-Terminal │      "+"      │      "*"      │      "("      │  ")"   │   "id"   │   $    │`,
+				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
+				`│      E       │               │               │   E → T E′    │        │ E → T E′ │        │`,
+				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
+				`│      E′      │ E′ → "+" T E′ │               │               │ E′ → ε │          │ E′ → ε │`,
+				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
+				`│      T       │               │               │   T → F T′    │        │ T → F T′ │        │`,
+				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
+				`│      T′      │    T′ → ε     │ T′ → "*" F T′ │               │ T′ → ε │          │ T′ → ε │`,
+				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
+				`│      F       │               │               │ F → "(" E ")" │        │ F → "id" │        │`,
+				`└──────────────┴───────────────┴───────────────┴───────────────┴────────┴──────────┴────────┘`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := tc.pt.String()
+
+			for _, expectedSubstring := range tc.expectedSubstrings {
+				assert.Contains(t, s, expectedSubstring)
+			}
+		})
+	}
+}
+
+func TestParsingTable_Equals(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name           string
+		pt             *parsingTable
+		rhs            ParsingTable
+		expectedEquals bool
+	}{
+		{
+			name:           "Equal",
+			pt:             pt[0],
+			rhs:            pt[0],
+			expectedEquals: true,
+		},
+		{
+			name:           "NotEqual",
+			pt:             pt[1],
+			rhs:            pt[2],
+			expectedEquals: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedEquals, tc.pt.Equals(tc.rhs))
+		})
+	}
+}
+
+func TestParsingTable_Add(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name       string
+		pt         *parsingTable
+		A          NonTerminal
+		a          Terminal
+		prod       Production
+		expectedOK bool
+	}{
+		{
+			name: "OK",
+			pt:   pt[2],
+			A:    NonTerminal("F"),
+			a:    Terminal("("),
+			prod: Production{"F", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.pt.Add(tc.A, tc.a, tc.prod)
+		})
+	}
+}
+
+func TestParsingTable_Get(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name                string
+		pt                  *parsingTable
+		A                   NonTerminal
+		a                   Terminal
+		expectedProductions set.Set[Production]
+	}{
+		{
+			name: "OK",
+			pt:   pt[0],
+			A:    NonTerminal("E′"),
+			a:    Terminal("+"),
+			expectedProductions: set.New(eqProduction,
+				Production{"E′", String[Symbol]{Terminal("+"), NonTerminal("T"), NonTerminal("E′")}},
+			),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prods := tc.pt.Get(tc.A, tc.a)
+			assert.True(t, prods.Equals(tc.expectedProductions))
+		})
+	}
+}
+
+func TestParsingTable_CheckErrors(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name                 string
+		pt                   *parsingTable
+		expectedErrorStrings []string
+	}{
+		{
+			name:                 "NoError",
+			pt:                   pt[0],
+			expectedErrorStrings: nil,
+		},
+		{
+			name: "Error",
+			pt:   pt[1],
+			expectedErrorStrings: []string{
+				`multiple productions in parsing table at M[S′, "e"]`,
+				`S′ → "e" S`,
+				`S′ → ε`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.pt.CheckErrors()
+
+			if len(tc.expectedErrorStrings) == 0 {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				s := err.Error()
+				for _, expectedErrorString := range tc.expectedErrorStrings {
+					assert.Contains(t, s, expectedErrorString)
+				}
+			}
+		})
+	}
+}

--- a/grammar/production.go
+++ b/grammar/production.go
@@ -102,7 +102,12 @@ type productions struct {
 // NewProductions creates a new instance of the Productions.
 func NewProductions() Productions {
 	return &productions{
-		table: symboltable.NewQuadraticHashTable(hashNonTerminal, eqNonTerminal, eqProductionSet, symboltable.HashOpts{}),
+		table: symboltable.NewQuadraticHashTable(
+			hashNonTerminal,
+			eqNonTerminal,
+			eqProductionSet,
+			symboltable.HashOpts{},
+		),
 	}
 }
 

--- a/grammar/production.go
+++ b/grammar/production.go
@@ -87,7 +87,6 @@ type Productions interface {
 	Remove(...Production)
 	RemoveAll(...NonTerminal)
 	Get(NonTerminal) set.Set[Production]
-	Order(NonTerminal) []Production
 	All() iter.Seq[Production]
 	AllByHead() iter.Seq2[NonTerminal, set.Set[Production]]
 	AnyMatch(generic.Predicate1[Production]) bool
@@ -115,9 +114,9 @@ func NewProductions() Productions {
 func (p *productions) String() string {
 	var b bytes.Buffer
 
-	for head := range p.table.All() {
+	for head, prods := range p.table.All() {
 		fmt.Fprintf(&b, "%s → ", head)
-		for _, q := range p.Order(head) {
+		for _, q := range orderProductionSet(prods) {
 			fmt.Fprintf(&b, "%s | ", q.Body.String())
 		}
 		b.Truncate(b.Len() - 3)
@@ -185,53 +184,6 @@ func (p *productions) Get(head NonTerminal) set.Set[Production] {
 	return list
 }
 
-// Order orders an unordered set of production rules with the same head non-terminal in a deterministic way.
-//
-// The ordering criteria are as follows:
-//
-//  1. Productions whose bodies contain more non-terminal symbols are prioritized first.
-//  2. If two productions have the same number of non-terminals, those with more terminal symbols in the body come first.
-//  3. If two productions have the same number of non-terminals and terminals, they are ordered alphabetically based on the symbols in their bodies.
-//
-// The goal of this function is to ensure a consistent and deterministic order for any given set of production rules.
-func (p *productions) Order(head NonTerminal) []Production {
-	// Collect all production rules into a slice from the set iterator.
-	prods := generic.Collect1(p.Get(head).All())
-
-	// Sort the productions using a custom comparison function.
-	sort.Quick[Production](prods, func(lhs, rhs Production) int {
-		// First, compare based on the number of non-terminal symbols in the body.
-		lhsNonTermsLen, rhsNonTermsLen := len(lhs.Body.NonTerminals()), len(rhs.Body.NonTerminals())
-		if lhsNonTermsLen > rhsNonTermsLen {
-			return -1
-		} else if rhsNonTermsLen > lhsNonTermsLen {
-			return 1
-		}
-
-		// Next, if the number of non-terminals is the same,
-		//   compare based on the number of terminal symbols.
-		lhsTermsLen, rhsTermsLen := len(lhs.Body.Terminals()), len(rhs.Body.Terminals())
-		if lhsTermsLen > rhsTermsLen {
-			return -1
-		} else if rhsTermsLen > lhsTermsLen {
-			return 1
-		}
-
-		// Then, if the number of terminals is also the same,
-		//   compare alphabetically based on the string representation of the bodies.
-		lhsString, rhsString := lhs.String(), rhs.String()
-		if lhsString < rhsString {
-			return -1
-		} else if rhsString < lhsString {
-			return 1
-		}
-
-		return 0
-	})
-
-	return prods
-}
-
 // All returns an iterator sequence containing all production rules.
 func (p *productions) All() iter.Seq[Production] {
 	return func(yield func(Production) bool) {
@@ -286,4 +238,64 @@ func (p *productions) SelectMatch(pred generic.Predicate1[Production]) Productio
 	}
 
 	return newP
+}
+
+// OrderProductions orders an unordered set of production rules in a deterministic way.
+//
+// The ordering criteria are as follows:
+//
+//  1. Production heads are compared alphabetically.
+//  2. If two productions have the same heads,
+//     productions whose bodies contain more non-terminal symbols are prioritized first.
+//  3. If two productions have the same number of non-terminals,
+//     those with more terminal symbols in the body come first.
+//  4. If two productions have the same number of non-terminals and terminals,
+//     they are ordered alphabetically based on the symbols in their bodies.
+//
+// The goal of this function is to ensure a consistent and deterministic order for any given set of production rules.
+func orderProductionSet(set set.Set[Production]) []Production {
+	prods := generic.Collect1(set.All())
+	orderProductionSlice(prods)
+	return prods
+}
+
+func orderProductionSlice(prods []Production) {
+	// Sort the productions using a custom comparison function.
+	sort.Quick[Production](prods, func(lhs, rhs Production) int {
+		// First, compare the heads of productions.
+		if cmp := cmpNonTerminal(lhs.Head, rhs.Head); cmp < 0 {
+			return -1
+		} else if cmp > 0 {
+			return 1
+		}
+
+		// Second, if the heads of two productions are the same,
+		//   compare based on the number of non-terminal symbols in the body.
+		lhsNonTermsLen, rhsNonTermsLen := len(lhs.Body.NonTerminals()), len(rhs.Body.NonTerminals())
+		if lhsNonTermsLen > rhsNonTermsLen {
+			return -1
+		} else if rhsNonTermsLen > lhsNonTermsLen {
+			return 1
+		}
+
+		// Next, if the number of non-terminals is the same,
+		//   compare based on the number of terminal symbols.
+		lhsTermsLen, rhsTermsLen := len(lhs.Body.Terminals()), len(rhs.Body.Terminals())
+		if lhsTermsLen > rhsTermsLen {
+			return -1
+		} else if rhsTermsLen > lhsTermsLen {
+			return 1
+		}
+
+		// Then, if the number of terminals is also the same,
+		//   compare alphabetically based on the string representation of the bodies.
+		lhsString, rhsString := lhs.String(), rhs.String()
+		if lhsString < rhsString {
+			return -1
+		} else if rhsString < lhsString {
+			return 1
+		}
+
+		return 0
+	})
 }

--- a/grammar/production_test.go
+++ b/grammar/production_test.go
@@ -480,59 +480,6 @@ func TestProductions_Get(t *testing.T) {
 	}
 }
 
-func TestProductions_Order(t *testing.T) {
-	p := getTestProductions()
-
-	tests := []struct {
-		name                string
-		p                   *productions
-		head                NonTerminal
-		expectedProductions []Production
-	}{
-		{
-			name: "1st",
-			p:    p[1],
-			head: NonTerminal("S"),
-			expectedProductions: []Production{
-				{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}, // S → aSbS
-				{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}, // S → bSaS
-				{"S", ε}, // S → ε
-			},
-		},
-		{
-			name: "2nd",
-			p:    p[2],
-			head: NonTerminal("T"),
-			expectedProductions: []Production{
-				{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
-				{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
-				{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
-			},
-		},
-		{
-			name: "3rd",
-			p:    p[3],
-			head: NonTerminal("E"),
-			expectedProductions: []Production{
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}, // E → E * E
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}, // E → E + E
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}, // E → E - E
-				{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}, // E → E / E
-				{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
-				{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}},                   // E → - E
-				{"E", String[Symbol]{Terminal("id")}},                                    // E → id
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			prods := tc.p.Order(tc.head)
-			assert.Equal(t, tc.expectedProductions, prods)
-		})
-	}
-}
-
 func TestProductions_All(t *testing.T) {
 	p := getTestProductions()
 
@@ -738,6 +685,55 @@ func TestProductions_SelectMatch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			selectMatch := tc.p.SelectMatch(tc.pred)
 			assert.True(t, selectMatch.Equals(tc.expectedSelectMatch))
+		})
+	}
+}
+
+func TestOrderProductionSet(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name                string
+		set                 set.Set[Production]
+		expectedProductions []Production
+	}{
+		{
+			name: "1st",
+			set:  p[1].Get("S"),
+			expectedProductions: []Production{
+				{"S", String[Symbol]{Terminal("a"), NonTerminal("S"), Terminal("b"), NonTerminal("S")}}, // S → aSbS
+				{"S", String[Symbol]{Terminal("b"), NonTerminal("S"), Terminal("a"), NonTerminal("S")}}, // S → bSaS
+				{"S", ε}, // S → ε
+			},
+		},
+		{
+			name: "2nd",
+			set:  p[2].Get("T"),
+			expectedProductions: []Production{
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("*"), NonTerminal("F")}}, // T → T * F
+				{"T", String[Symbol]{NonTerminal("T"), Terminal("/"), NonTerminal("F")}}, // T → T / F
+				{"T", String[Symbol]{NonTerminal("F")}},                                  // T → F
+			},
+		},
+		{
+			name: "3rd",
+			set:  p[3].Get("E"),
+			expectedProductions: []Production{
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("*"), NonTerminal("E")}}, // E → E * E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("+"), NonTerminal("E")}}, // E → E + E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("-"), NonTerminal("E")}}, // E → E - E
+				{"E", String[Symbol]{NonTerminal("E"), Terminal("/"), NonTerminal("E")}}, // E → E / E
+				{"E", String[Symbol]{Terminal("("), NonTerminal("E"), Terminal(")")}},    // E → ( E )
+				{"E", String[Symbol]{Terminal("-"), NonTerminal("E")}},                   // E → - E
+				{"E", String[Symbol]{Terminal("id")}},                                    // E → id
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prods := orderProductionSet(tc.set)
+			assert.Equal(t, tc.expectedProductions, prods)
 		})
 	}
 }

--- a/grammar/symbol.go
+++ b/grammar/symbol.go
@@ -17,7 +17,7 @@ import (
 // to simplify the handling of end-of-input scenarios, especially in parsing algorithms like LL(1) or LR(1).
 //
 // For more information and details, see "Compilers: Principles, Techniques, and Tools (2nd Edition)".
-// const endmarker rune = 0xEEEE
+var endmarker = Terminal("\uEEEE")
 
 var (
 	hashSymbol = hashFuncForSymbol()
@@ -25,8 +25,9 @@ var (
 		return lhs.Equals(rhs)
 	}
 
-	eqTerminal  = generic.NewEqualFunc[Terminal]()
-	cmpTerminal = generic.NewCompareFunc[Terminal]()
+	eqTerminal   = generic.NewEqualFunc[Terminal]()
+	cmpTerminal  = generic.NewCompareFunc[Terminal]()
+	hashTerminal = hash.HashFuncForString[Terminal](nil)
 
 	eqNonTerminal   = generic.NewEqualFunc[NonTerminal]()
 	cmpNonTerminal  = generic.NewCompareFunc[NonTerminal]()
@@ -66,11 +67,23 @@ type Terminal string
 
 // String returns a string representation of a terminal symbol.
 func (t Terminal) String() string {
+	// The special endmarker symbol is taken from a Private Use Area (PUA) in Unicode,
+	// and it is rendered as $.
+	if t.Equals(endmarker) {
+		return "$"
+	}
+
 	return fmt.Sprintf("%q", t.Name())
 }
 
 // Name returns the name of terminal symbol.
 func (t Terminal) Name() string {
+	// The special endmarker symbol is taken from a Private Use Area (PUA) in Unicode,
+	// and it is named as $.
+	if t.Equals(endmarker) {
+		return "$"
+	}
+
 	return string(t)
 }
 

--- a/grammar/symbol_test.go
+++ b/grammar/symbol_test.go
@@ -66,6 +66,15 @@ func TestHashFuncForSymbol(t *testing.T) {
 }
 
 func TestTerminal(t *testing.T) {
+	t.Run("endmarker", func(t *testing.T) {
+		assert.Equal(t, "$", endmarker.String())
+		assert.Equal(t, "$", endmarker.Name())
+		assert.True(t, endmarker.Equals(Terminal("\uEEEE")))
+		assert.False(t, endmarker.Equals(NonTerminal("\uEEEE")))
+		assert.False(t, endmarker.Equals(Terminal("\uEEEF")))
+		assert.True(t, endmarker.IsTerminal())
+	})
+
 	tests := []struct {
 		value          string
 		expectedString string
@@ -81,6 +90,7 @@ func TestTerminal(t *testing.T) {
 		{value: "(", expectedString: `"("`},
 		{value: ")", expectedString: `")"`},
 		{value: "id", expectedString: `"id"`},
+		{value: "if", expectedString: `"if"`},
 		{value: "if", expectedString: `"if"`},
 	}
 

--- a/grammar/symbol_test.go
+++ b/grammar/symbol_test.go
@@ -81,7 +81,6 @@ func TestTerminal(t *testing.T) {
 	}{
 		{value: "a", expectedString: `"a"`},
 		{value: "b", expectedString: `"b"`},
-		{value: "c", expectedString: `"c"`},
 		{value: "0", expectedString: `"0"`},
 		{value: "1", expectedString: `"1"`},
 		{value: "2", expectedString: `"2"`},


### PR DESCRIPTION
## Description

  - [x] Make the special end market symbol a terminal symbol.
  - [x] Implement `ParsingTable` to create predictive parsing tables.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
