### PR TITLE
Add error recovery for predictive parsing

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -49,7 +49,7 @@ func (t Token) String() string {
 	return fmt.Sprintf("%s <%s, %s>", t.Terminal, t.Lexeme, t.Pos)
 }
 
-// Position represents the specific location in an input source.
+// Position represents a specific location in an input source.
 type Position struct {
 	Filename string // The name of the input source file (optional).
 	Offset   int    // The byte offset from the beginning of the file.

--- a/parser/predictive/parsing_table_test.go
+++ b/parser/predictive/parsing_table_test.go
@@ -14,31 +14,41 @@ func getTestParsingTables() []*parsingTable {
 		[]grammar.NonTerminal{"E", "E′", "T", "T′", "F"},
 	)
 
-	pt0.Add("E", "id", grammar.Production{Head: "E", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("T"), grammar.NonTerminal("E′")}})
-	pt0.Add("E", "(", grammar.Production{Head: "E", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("T"), grammar.NonTerminal("E′")}})
-	pt0.Add("E′", "+", grammar.Production{Head: "E′", Body: grammar.String[grammar.Symbol]{grammar.Terminal("+"), grammar.NonTerminal("T"), grammar.NonTerminal("E′")}})
-	pt0.Add("E′", ")", grammar.Production{Head: "E′", Body: grammar.E})
-	pt0.Add("E′", grammar.Endmarker, grammar.Production{Head: "E′", Body: grammar.E})
-	pt0.Add("T", "id", grammar.Production{Head: "T", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("F"), grammar.NonTerminal("T′")}})
-	pt0.Add("T", "(", grammar.Production{Head: "T", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("F"), grammar.NonTerminal("T′")}})
-	pt0.Add("T′", "+", grammar.Production{Head: "T′", Body: grammar.E})
-	pt0.Add("T′", "*", grammar.Production{Head: "T′", Body: grammar.String[grammar.Symbol]{grammar.Terminal("*"), grammar.NonTerminal("F"), grammar.NonTerminal("T′")}})
-	pt0.Add("T′", ")", grammar.Production{Head: "T′", Body: grammar.E})
-	pt0.Add("T′", grammar.Endmarker, grammar.Production{Head: "T′", Body: grammar.E})
-	pt0.Add("F", "id", grammar.Production{Head: "F", Body: grammar.String[grammar.Symbol]{grammar.Terminal("id")}})
-	pt0.Add("F", "(", grammar.Production{Head: "F", Body: grammar.String[grammar.Symbol]{grammar.Terminal("("), grammar.NonTerminal("E"), grammar.Terminal(")")}})
+	pt0.AddProduction("E", "id", grammar.Production{Head: "E", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("T"), grammar.NonTerminal("E′")}})
+	pt0.AddProduction("E", "(", grammar.Production{Head: "E", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("T"), grammar.NonTerminal("E′")}})
+	pt0.AddProduction("E′", "+", grammar.Production{Head: "E′", Body: grammar.String[grammar.Symbol]{grammar.Terminal("+"), grammar.NonTerminal("T"), grammar.NonTerminal("E′")}})
+	pt0.AddProduction("E′", ")", grammar.Production{Head: "E′", Body: grammar.E})
+	pt0.AddProduction("E′", grammar.Endmarker, grammar.Production{Head: "E′", Body: grammar.E})
+	pt0.AddProduction("T", "id", grammar.Production{Head: "T", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("F"), grammar.NonTerminal("T′")}})
+	pt0.AddProduction("T", "(", grammar.Production{Head: "T", Body: grammar.String[grammar.Symbol]{grammar.NonTerminal("F"), grammar.NonTerminal("T′")}})
+	pt0.AddProduction("T′", "+", grammar.Production{Head: "T′", Body: grammar.E})
+	pt0.AddProduction("T′", "*", grammar.Production{Head: "T′", Body: grammar.String[grammar.Symbol]{grammar.Terminal("*"), grammar.NonTerminal("F"), grammar.NonTerminal("T′")}})
+	pt0.AddProduction("T′", ")", grammar.Production{Head: "T′", Body: grammar.E})
+	pt0.AddProduction("T′", grammar.Endmarker, grammar.Production{Head: "T′", Body: grammar.E})
+	pt0.AddProduction("F", "id", grammar.Production{Head: "F", Body: grammar.String[grammar.Symbol]{grammar.Terminal("id")}})
+	pt0.AddProduction("F", "(", grammar.Production{Head: "F", Body: grammar.String[grammar.Symbol]{grammar.Terminal("("), grammar.NonTerminal("E"), grammar.Terminal(")")}})
+
+	pt0.SetSync("E", ")", true)
+	pt0.SetSync("E", grammar.Endmarker, true)
+	pt0.SetSync("T", "+", true)
+	pt0.SetSync("T", ")", true)
+	pt0.SetSync("T", grammar.Endmarker, true)
+	pt0.SetSync("F", "+", true)
+	pt0.SetSync("F", "*", true)
+	pt0.SetSync("F", ")", true)
+	pt0.SetSync("F", grammar.Endmarker, true)
 
 	pt1 := newParsingTable(
 		[]grammar.Terminal{"a", "b", "e", "i", "t"},
 		[]grammar.NonTerminal{"S", "S′", "E"},
 	)
 
-	pt1.Add("S", "a", grammar.Production{Head: "S", Body: grammar.String[grammar.Symbol]{grammar.Terminal("a")}})
-	pt1.Add("S", "i", grammar.Production{Head: "S", Body: grammar.String[grammar.Symbol]{grammar.Terminal("i"), grammar.NonTerminal("E"), grammar.Terminal("t"), grammar.NonTerminal("S"), grammar.NonTerminal("S′")}})
-	pt1.Add("S′", "e", grammar.Production{Head: "S′", Body: grammar.E})
-	pt1.Add("S′", "e", grammar.Production{Head: "S′", Body: grammar.String[grammar.Symbol]{grammar.Terminal("e"), grammar.NonTerminal("S")}})
-	pt1.Add("S′", grammar.Endmarker, grammar.Production{Head: "S′", Body: grammar.E})
-	pt1.Add("E", "b", grammar.Production{Head: "E", Body: grammar.String[grammar.Symbol]{grammar.Terminal("b")}})
+	pt1.AddProduction("S", "a", grammar.Production{Head: "S", Body: grammar.String[grammar.Symbol]{grammar.Terminal("a")}})
+	pt1.AddProduction("S", "i", grammar.Production{Head: "S", Body: grammar.String[grammar.Symbol]{grammar.Terminal("i"), grammar.NonTerminal("E"), grammar.Terminal("t"), grammar.NonTerminal("S"), grammar.NonTerminal("S′")}})
+	pt1.AddProduction("S′", "e", grammar.Production{Head: "S′", Body: grammar.E})
+	pt1.AddProduction("S′", "e", grammar.Production{Head: "S′", Body: grammar.String[grammar.Symbol]{grammar.Terminal("e"), grammar.NonTerminal("S")}})
+	pt1.AddProduction("S′", grammar.Endmarker, grammar.Production{Head: "S′", Body: grammar.E})
+	pt1.AddProduction("E", "b", grammar.Production{Head: "E", Body: grammar.String[grammar.Symbol]{grammar.Terminal("b")}})
 
 	pt2 := newParsingTable(
 		[]grammar.Terminal{"+", "*", "(", ")", "id"},
@@ -49,9 +59,12 @@ func getTestParsingTables() []*parsingTable {
 }
 
 func TestBuildParsingTable(t *testing.T) {
+	pt := getTestParsingTables()
+
 	tests := []struct {
 		name                 string
 		G                    grammar.CFG
+		expectedTable        ParsingTable
 		expectedErrorStrings []string
 	}{
 		{
@@ -75,6 +88,7 @@ func TestBuildParsingTable(t *testing.T) {
 		},
 		{
 			name:                 "3rd",
+			expectedTable:        pt[0],
 			G:                    CFGrammars[2],
 			expectedErrorStrings: nil,
 		},
@@ -105,6 +119,7 @@ func TestBuildParsingTable(t *testing.T) {
 
 			if len(tc.expectedErrorStrings) == 0 {
 				assert.NoError(t, err)
+				assert.True(t, table.Equals(tc.expectedTable))
 			} else {
 				assert.Error(t, err)
 				s := err.Error()
@@ -133,15 +148,15 @@ func TestParsingTable_String(t *testing.T) {
 				`├──────────────┼───────────────┬───────────────┬───────────────┬────────┬──────────┬────────┤`,
 				`│ Non-Terminal │      "+"      │      "*"      │      "("      │  ")"   │   "id"   │   $    │`,
 				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
-				`│      E       │               │               │   E → T E′    │        │ E → T E′ │        │`,
+				`│      E       │               │               │   E → T E′    │  sync  │ E → T E′ │  sync  │`,
 				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
 				`│      E′      │ E′ → "+" T E′ │               │               │ E′ → ε │          │ E′ → ε │`,
 				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
-				`│      T       │               │               │   T → F T′    │        │ T → F T′ │        │`,
+				`│      T       │     sync      │               │   T → F T′    │  sync  │ T → F T′ │  sync  │`,
 				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
 				`│      T′      │    T′ → ε     │ T′ → "*" F T′ │               │ T′ → ε │          │ T′ → ε │`,
 				`├──────────────┼───────────────┼───────────────┼───────────────┼────────┼──────────┼────────┤`,
-				`│      F       │               │               │ F → "(" E ")" │        │ F → "id" │        │`,
+				`│      F       │     sync      │     sync      │ F → "(" E ")" │  sync  │ F → "id" │  sync  │`,
 				`└──────────────┴───────────────┴───────────────┴───────────────┴────────┴──────────┴────────┘`,
 			},
 		},
@@ -188,62 +203,6 @@ func TestParsingTable_Equals(t *testing.T) {
 	}
 }
 
-func TestParsingTable_Add(t *testing.T) {
-	pt := getTestParsingTables()
-
-	tests := []struct {
-		name       string
-		pt         *parsingTable
-		A          grammar.NonTerminal
-		a          grammar.Terminal
-		prod       grammar.Production
-		expectedOK bool
-	}{
-		{
-			name: "OK",
-			pt:   pt[2],
-			A:    grammar.NonTerminal("F"),
-			a:    grammar.Terminal("("),
-			prod: grammar.Production{Head: "F", Body: grammar.String[grammar.Symbol]{grammar.Terminal("("), grammar.NonTerminal("E"), grammar.Terminal(")")}},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tc.pt.Add(tc.A, tc.a, tc.prod)
-		})
-	}
-}
-
-func TestParsingTable_Get(t *testing.T) {
-	pt := getTestParsingTables()
-
-	tests := []struct {
-		name                string
-		pt                  *parsingTable
-		A                   grammar.NonTerminal
-		a                   grammar.Terminal
-		expectedProductions set.Set[grammar.Production]
-	}{
-		{
-			name: "OK",
-			pt:   pt[0],
-			A:    grammar.NonTerminal("E′"),
-			a:    grammar.Terminal("+"),
-			expectedProductions: set.New(grammar.EqProduction,
-				grammar.Production{Head: "E′", Body: grammar.String[grammar.Symbol]{grammar.Terminal("+"), grammar.NonTerminal("T"), grammar.NonTerminal("E′")}},
-			),
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			prods := tc.pt.Get(tc.A, tc.a)
-			assert.True(t, prods.Equals(tc.expectedProductions))
-		})
-	}
-}
-
 func TestParsingTable_Error(t *testing.T) {
 	pt := getTestParsingTables()
 
@@ -280,6 +239,255 @@ func TestParsingTable_Error(t *testing.T) {
 				for _, expectedErrorString := range tc.expectedErrorStrings {
 					assert.Contains(t, s, expectedErrorString)
 				}
+			}
+		})
+	}
+}
+
+func TestParsingTable_AddProduction(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name       string
+		pt         *parsingTable
+		A          grammar.NonTerminal
+		a          grammar.Terminal
+		prod       grammar.Production
+		expectedOK bool
+	}{
+		{
+			name: "OK",
+			pt:   pt[2],
+			A:    grammar.NonTerminal("F"),
+			a:    grammar.Terminal("("),
+			prod: grammar.Production{
+				Head: "F",
+				Body: grammar.String[grammar.Symbol]{grammar.Terminal("("), grammar.NonTerminal("E"), grammar.Terminal(")")},
+			},
+			expectedOK: true,
+		},
+		{
+			name: "IsSync",
+			pt:   pt[0],
+			A:    grammar.NonTerminal("F"),
+			a:    grammar.Terminal(")"),
+			prod: grammar.Production{
+				Head: "F",
+				Body: grammar.String[grammar.Symbol]{grammar.Terminal("("), grammar.NonTerminal("E"), grammar.Terminal(")")},
+			},
+			expectedOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ok := tc.pt.AddProduction(tc.A, tc.a, tc.prod)
+			assert.Equal(t, tc.expectedOK, ok)
+
+			if tc.expectedOK {
+				e, ok := tc.pt.getEntry(tc.A, tc.a)
+				assert.True(t, ok)
+				assert.True(t, e.Productions.Contains(tc.prod))
+			}
+		})
+	}
+}
+
+func TestParsingTable_SetSync(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name       string
+		pt         *parsingTable
+		A          grammar.NonTerminal
+		a          grammar.Terminal
+		sync       bool
+		expectedOK bool
+	}{
+		{
+			name:       "OK",
+			pt:         pt[0],
+			A:          grammar.NonTerminal("F"),
+			a:          grammar.Terminal(")"),
+			sync:       true,
+			expectedOK: true,
+		},
+		{
+			name:       "HasProduction",
+			pt:         pt[0],
+			A:          grammar.NonTerminal("F"),
+			a:          grammar.Terminal("("),
+			sync:       false,
+			expectedOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ok := tc.pt.SetSync(tc.A, tc.a, tc.sync)
+			assert.Equal(t, tc.expectedOK, ok)
+
+			if tc.expectedOK {
+				e, ok := tc.pt.getEntry(tc.A, tc.a)
+				assert.True(t, ok)
+				assert.Equal(t, tc.sync, e.Sync)
+			}
+		})
+	}
+}
+
+func TestParsingTable_IsEmpty(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name            string
+		pt              *parsingTable
+		A               grammar.NonTerminal
+		a               grammar.Terminal
+		expectedIsEmpty bool
+	}{
+		{
+			name:            "Empty",
+			pt:              pt[0],
+			A:               grammar.NonTerminal("E"),
+			a:               grammar.Terminal("+"),
+			expectedIsEmpty: true,
+		},
+		{
+			name:            "NotEmpty",
+			pt:              pt[0],
+			A:               grammar.NonTerminal("E"),
+			a:               grammar.Terminal("id"),
+			expectedIsEmpty: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedIsEmpty, tc.pt.IsEmpty(tc.A, tc.a))
+		})
+	}
+}
+
+func TestParsingTable_IsSync(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name           string
+		pt             *parsingTable
+		A              grammar.NonTerminal
+		a              grammar.Terminal
+		expectedIsSync bool
+	}{
+		{
+			name:           "Sync",
+			pt:             pt[0],
+			A:              grammar.NonTerminal("E"),
+			a:              grammar.Terminal(")"),
+			expectedIsSync: true,
+		},
+		{
+			name:           "NotSync",
+			pt:             pt[0],
+			A:              grammar.NonTerminal("E"),
+			a:              grammar.Terminal("*"),
+			expectedIsSync: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedIsSync, tc.pt.IsSync(tc.A, tc.a))
+		})
+	}
+}
+
+func TestParsingTable_GetProduction(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name               string
+		pt                 *parsingTable
+		A                  grammar.NonTerminal
+		a                  grammar.Terminal
+		expectedOK         bool
+		expectedProduction grammar.Production
+	}{
+		{
+			name:               "Empty",
+			pt:                 pt[0],
+			A:                  grammar.NonTerminal("E"),
+			a:                  grammar.Terminal("+"),
+			expectedOK:         false,
+			expectedProduction: grammar.Production{},
+		},
+		{
+			name:       "OK",
+			pt:         pt[0],
+			A:          grammar.NonTerminal("E′"),
+			a:          grammar.Terminal("+"),
+			expectedOK: true,
+			expectedProduction: grammar.Production{
+				Head: "E′",
+				Body: grammar.String[grammar.Symbol]{grammar.Terminal("+"), grammar.NonTerminal("T"), grammar.NonTerminal("E′")},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prod, ok := tc.pt.GetProduction(tc.A, tc.a)
+
+			assert.Equal(t, tc.expectedOK, ok)
+			assert.True(t, prod.Equals(tc.expectedProduction))
+		})
+	}
+}
+
+func TestParsingTable_GetProductions(t *testing.T) {
+	pt := getTestParsingTables()
+
+	tests := []struct {
+		name                string
+		pt                  *parsingTable
+		A                   grammar.NonTerminal
+		a                   grammar.Terminal
+		expectedOK          bool
+		expectedProductions set.Set[grammar.Production]
+	}{
+		{
+			name:                "Empty",
+			pt:                  pt[0],
+			A:                   grammar.NonTerminal("E"),
+			a:                   grammar.Terminal("+"),
+			expectedOK:          false,
+			expectedProductions: nil,
+		},
+		{
+			name:       "OK",
+			pt:         pt[0],
+			A:          grammar.NonTerminal("E′"),
+			a:          grammar.Terminal("+"),
+			expectedOK: true,
+			expectedProductions: set.New(grammar.EqProduction,
+				grammar.Production{
+					Head: "E′",
+					Body: grammar.String[grammar.Symbol]{grammar.Terminal("+"), grammar.NonTerminal("T"), grammar.NonTerminal("E′")},
+				},
+			),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prods, ok := tc.pt.GetProductions(tc.A, tc.a)
+
+			if tc.expectedOK {
+				assert.True(t, ok)
+				assert.True(t, prods.Equals(tc.expectedProductions))
+			} else {
+				assert.False(t, ok)
+				assert.Nil(t, prods)
 			}
 		})
 	}

--- a/parser/predictive/predictive.go
+++ b/parser/predictive/predictive.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/moorara/algo/generic"
 	"github.com/moorara/algo/grammar"
 	"github.com/moorara/algo/lexer"
 	"github.com/moorara/algo/list"
@@ -119,9 +118,8 @@ func (p *predictiveParser) Parse(yield parser.Action) error {
 		}
 
 		A := X.(grammar.NonTerminal)
-		prods := M.Get(A, token.Terminal)
 
-		if prods.Size() == 0 {
+		if M.IsEmpty(A, token.Terminal) {
 			return &ParseError{
 				description: fmt.Sprintf("unacceptable input <%s, %s> for non-terminal %s", token.Terminal, token.Lexeme, A),
 				Pos:         token.Pos,
@@ -129,7 +127,8 @@ func (p *predictiveParser) Parse(yield parser.Action) error {
 			}
 		}
 
-		P := generic.Collect1(prods.All())[0]
+		// At this point, it is guaranteed that M[A,a] contains exactly one production.
+		P, _ := M.GetProduction(A, token.Terminal)
 
 		// Pop X from the stack.
 		stack.Pop()


### PR DESCRIPTION
## Description

  - [x] Add **synchornization** flag to `ParsingTable`.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
