### PR TITLE
parser: Escape especial characters in DOT code for internal nodes

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/moorara/algo/generic"
 	"github.com/moorara/algo/grammar"
@@ -252,8 +253,14 @@ func (n *InternalNode) DOT() string {
 
 		body := dot.NewRecord()
 		for i, X := range in.Production.Body {
+			label := strings.ReplaceAll(X.String(), "|", "\\|")
+			label = strings.ReplaceAll(label, "{", "\\{")
+			label = strings.ReplaceAll(label, "}", "\\}")
+			label = strings.ReplaceAll(label, "<", "\\<")
+			label = strings.ReplaceAll(label, ">", "\\>")
+
 			body.Fields = append(body.Fields,
-				dot.NewSimpleField(fmt.Sprintf("%d", i), X.String()),
+				dot.NewSimpleField(fmt.Sprintf("%d", i), label),
 			)
 		}
 
@@ -353,6 +360,7 @@ func (n *LeafNode) Annotation() any {
 // This format is commonly used for visualizing graphs with Graphviz tools.
 func (n *LeafNode) DOT() string {
 	label := fmt.Sprintf("%s <%s>", n.Terminal, n.Lexeme)
+
 	graph := dot.NewGraph(false, false, false, "", "", "", "", "")
 	graph.AddNode(dot.NewNode("1", "", label, "", dot.StyleBold, "", "", ""))
 


### PR DESCRIPTION
## Description

  - [x] Escape `|`, `{`, `}`, `<`, and `>` in generated DOT code for internal nodes in AST

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
