### PR TITLE
Implement Stringer interface for PrecedenceLevel and PrecedenceLevels

### DIFF
--- a/parser/lr/precedence.go
+++ b/parser/lr/precedence.go
@@ -3,6 +3,7 @@ package lr
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/moorara/algo/errors"
 	"github.com/moorara/algo/generic"
@@ -72,6 +73,16 @@ func (p *ActionHandlePair) Equal(rhs *ActionHandlePair) bool {
 // for specific terminals or production rules of a context-free grammar.
 // The order of these levels is crucial for resolving conflicts.
 type PrecedenceLevels []*PrecedenceLevel
+
+// String returns a string representation of the list of precedence levels.
+func (p PrecedenceLevels) String() string {
+	levels := make([]string, len(p))
+	for i, l := range p {
+		levels[i] = l.String()
+	}
+
+	return strings.Join(levels, "\n")
+}
 
 // Equal determines whether or not two ordered list of precedence levels are the same.
 func (p PrecedenceLevels) Equal(rhs PrecedenceLevels) bool {
@@ -197,6 +208,11 @@ func (p PrecedenceLevels) Compare(lhs, rhs *ActionHandlePair) (int, error) {
 type PrecedenceLevel struct {
 	Associativity Associativity
 	Handles       PrecedenceHandles
+}
+
+// String returns a string representation of the precedence level.
+func (p *PrecedenceLevel) String() string {
+	return fmt.Sprintf("%s %s", p.Associativity, p.Handles)
 }
 
 // Equal determines whether or not two precedence levels are the same.

--- a/parser/lr/precedence_test.go
+++ b/parser/lr/precedence_test.go
@@ -89,6 +89,28 @@ func TestActionHandlePair(t *testing.T) {
 	}
 }
 
+func TestPrecedenceLevels_String(t *testing.T) {
+	tests := []struct {
+		name           string
+		p              PrecedenceLevels
+		expectedString string
+	}{
+		{
+			name: "Equal",
+			p:    precedences[0],
+			expectedString: `LEFT "*", "/"
+LEFT "+", "-"
+NONE "<", ">"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedString, tc.p.String())
+		})
+	}
+}
+
 func TestPrecedenceLevels_Equal(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -393,6 +415,26 @@ func TestPrecedenceLevels_Compare(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tc.expectedError)
 			}
+		})
+	}
+}
+
+func TestPrecedenceLevel_String(t *testing.T) {
+	tests := []struct {
+		name           string
+		p              *PrecedenceLevel
+		expectedString string
+	}{
+		{
+			name:           "OK",
+			p:              precedences[0][0],
+			expectedString: `LEFT "*", "/"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedString, tc.p.String())
 		})
 	}
 }


### PR DESCRIPTION
## Description

  - [x] Implement `Stringer` interface for `PrecedenceLevel` and `PrecedenceLevels` type.

### Checklist

  - [ ] PR title is clear and describes the change
  - [ ] Commit messages are self-explanatory and summarize the change
  - [ ] Tests are provided for the new change
