### PR TITLE
Use sorted set for managing automata states

### DIFF
--- a/automata/automata.go
+++ b/automata/automata.go
@@ -7,7 +7,6 @@ package automata
 import (
 	"github.com/moorara/algo/generic"
 	"github.com/moorara/algo/set"
-	"github.com/moorara/algo/sort"
 	"github.com/moorara/algo/symboltable"
 )
 
@@ -41,15 +40,7 @@ type States set.Set[State]
 
 // NewStates creates a new set of states, initialized with the given states.
 func NewStates(s ...State) States {
-	return set.New(eqState, s...)
-}
-
-// sortStates sorts a set of states into a canonical order, ensuring a consistent representation.
-func sortStates(states States) []State {
-	sorted := generic.Collect1(states.All())
-	sort.Quick(sorted, cmpState)
-
-	return sorted
+	return set.NewSorted(cmpState, s...)
 }
 
 // Symbol represents an input symbol in an automaton, identified by a rune.
@@ -63,15 +54,7 @@ type Symbols set.Set[Symbol]
 
 // NewSymbols creates a new set of symbols, initialized with the given symbols.
 func NewSymbols(a ...Symbol) set.Set[Symbol] {
-	return set.New(eqSymbol, a...)
-}
-
-// sortSymbols sorts a set of symbols into a canonical order, ensuring a consistent representation.
-func sortSymbols(symbols Symbols) []Symbol {
-	sorted := generic.Collect1(symbols.All())
-	sort.Insertion(sorted, cmpSymbol)
-
-	return sorted
+	return set.NewSorted(cmpSymbol, a...)
 }
 
 // String represents a sequence of symbols in an automaton.

--- a/automata/automata.go
+++ b/automata/automata.go
@@ -15,7 +15,7 @@ var (
 	cmpState = generic.NewCompareFunc[State]()
 	// hashState = hash.HashFuncForInt[State](nil)
 
-	eqSymbol  = generic.NewEqualFunc[Symbol]()
+	// eqSymbol  = generic.NewEqualFunc[Symbol]()
 	cmpSymbol = generic.NewCompareFunc[Symbol]()
 	// hashSymbol = hash.HashFuncForInt32[Symbol](nil)
 

--- a/automata/automata_test.go
+++ b/automata/automata_test.go
@@ -27,28 +27,6 @@ func TestNewStates(t *testing.T) {
 	}
 }
 
-func TestSortStates(t *testing.T) {
-	tests := []struct {
-		name           string
-		states         States
-		expectedStates []State
-	}{
-		{
-			name:           "OK",
-			states:         NewStates(2, 1, 3, 0),
-			expectedStates: []State{0, 1, 2, 3},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			states := sortStates(tc.states)
-
-			assert.Equal(t, tc.expectedStates, states)
-		})
-	}
-}
-
 func TestNewSymbols(t *testing.T) {
 	tests := []struct {
 		name string
@@ -66,28 +44,6 @@ func TestNewSymbols(t *testing.T) {
 
 			assert.NotNil(t, set)
 			assert.True(t, set.Contains(tc.a...))
-		})
-	}
-}
-
-func TestSortSymbols(t *testing.T) {
-	tests := []struct {
-		name            string
-		symbols         Symbols
-		expectedSymbols []Symbol
-	}{
-		{
-			name:            "OK",
-			symbols:         NewSymbols('c', 'd', 'b', 'a'),
-			expectedSymbols: []Symbol{'a', 'b', 'c', 'd'},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			symbols := sortSymbols(tc.symbols)
-
-			assert.Equal(t, tc.expectedSymbols, symbols)
 		})
 	}
 }

--- a/automata/dfa.go
+++ b/automata/dfa.go
@@ -45,7 +45,7 @@ func (d *DFA) String() string {
 	fmt.Fprintf(&b, "Start state: %d\n", d.Start)
 	fmt.Fprintf(&b, "Final states: ")
 
-	for _, s := range sortStates(d.Final) {
+	for s := range d.Final.All() {
 		fmt.Fprintf(&b, "%d, ", s)
 	}
 
@@ -109,7 +109,7 @@ func (d *DFA) Accept(s String) bool {
 
 // States returns the set of all states of the DFA.
 func (d *DFA) States() []State {
-	return sortStates(d.states())
+	return generic.Collect1(d.states().All())
 }
 
 func (d *DFA) states() States {
@@ -127,7 +127,7 @@ func (d *DFA) states() States {
 
 // Symbols returns the set of all input symbols of the DFA.
 func (d *DFA) Symbols() []Symbol {
-	return sortSymbols(d.symbols())
+	return generic.Collect1(d.symbols().All())
 }
 
 func (d *DFA) symbols() Symbols {

--- a/automata/nfa.go
+++ b/automata/nfa.go
@@ -84,7 +84,7 @@ func (n *NFA) String() string {
 	fmt.Fprintf(&b, "Start state: %d\n", n.Start)
 	fmt.Fprintf(&b, "Final states: ")
 
-	for _, s := range sortStates(n.Final) {
+	for s := range n.Final.All() {
 		fmt.Fprintf(&b, "%d, ", s)
 	}
 
@@ -138,7 +138,7 @@ func (n *NFA) Add(s State, a Symbol, next []State) {
 // If no valid transition exists, it returns nil
 func (n *NFA) Next(s State, a Symbol) []State {
 	if next := n.next(s, a); next != nil {
-		return sortStates(next)
+		return generic.Collect1(next.All())
 	}
 
 	return nil
@@ -172,7 +172,7 @@ func (n *NFA) Accept(s String) bool {
 
 // States returns the set of all states of the NFA.
 func (n *NFA) States() []State {
-	return sortStates(n.states())
+	return generic.Collect1(n.states().All())
 }
 
 func (n *NFA) states() States {
@@ -191,7 +191,7 @@ func (n *NFA) states() States {
 
 // Symbols returns the set of all input symbols of the NFA.
 func (n *NFA) Symbols() []Symbol {
-	return sortSymbols(n.symbols())
+	return generic.Collect1(n.symbols().All())
 }
 
 func (n *NFA) symbols() Symbols {
@@ -220,7 +220,7 @@ func (n *NFA) Star() *NFA {
 
 		for a, states := range strans.All() {
 			next := make([]State, 0, states.Size())
-			for _, t := range sortStates(states) {
+			for t := range states.All() {
 				tt := sm.GetOrCreateState(0, t)
 				next = append(next, tt)
 			}
@@ -233,7 +233,7 @@ func (n *NFA) Star() *NFA {
 	star.Add(start, E, []State{ss})
 	star.Add(start, E, []State{final})
 
-	for _, f := range sortStates(n.Final) {
+	for f := range n.Final.All() {
 		ff := sm.GetOrCreateState(0, f)
 		star.Add(ff, E, []State{ss})
 		star.Add(ff, E, []State{final})
@@ -256,7 +256,7 @@ func (n *NFA) Union(ns ...*NFA) *NFA {
 
 			for a, states := range strans.All() {
 				next := make([]State, 0, states.Size())
-				for _, t := range sortStates(states) {
+				for t := range states.All() {
 					tt := sm.GetOrCreateState(id, t)
 					next = append(next, tt)
 				}
@@ -268,7 +268,7 @@ func (n *NFA) Union(ns ...*NFA) *NFA {
 		ss := sm.GetOrCreateState(id, nfa.Start)
 		union.Add(start, E, []State{ss})
 
-		for _, f := range sortStates(nfa.Final) {
+		for f := range nfa.Final.All() {
 			ff := sm.GetOrCreateState(id, f)
 			union.Add(ff, E, []State{final})
 		}
@@ -301,7 +301,7 @@ func (n *NFA) Concat(ns ...*NFA) *NFA {
 				// If any of the next state is the start state of the current NFA,
 				// we need to map it to the previous NFA final states.
 				var nextp []State
-				for _, t := range sortStates(states) {
+				for t := range states.All() {
 					if t == nfa.Start {
 						nextp = append(nextp, final...)
 					} else {
@@ -319,7 +319,7 @@ func (n *NFA) Concat(ns ...*NFA) *NFA {
 
 		// Update the current final states
 		final = make([]State, 0, nfa.Final.Size())
-		for _, f := range sortStates(nfa.Final) {
+		for f := range nfa.Final.All() {
 			ff := sm.GetOrCreateState(id, f)
 			final = append(final, ff)
 		}


### PR DESCRIPTION
## Description

  - [x] Use `Sorted` set for managing `automata` states.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
