### PR TITLE
PrecedenceLevels: rename Validate to Verify

### DIFF
--- a/parser/lr/parsing_table.go
+++ b/parser/lr/parsing_table.go
@@ -177,7 +177,7 @@ func (t *ParsingTable) SetGOTO(s State, A grammar.NonTerminal, next State) {
 //
 // If a conflict cannot be resolved, a detailed error describing the conflict is created and accumulated.
 func (t *ParsingTable) ResolveConflicts() error {
-	if err := t.precedences.Validate(); err != nil {
+	if err := t.precedences.Verify(); err != nil {
 		return err
 	}
 

--- a/parser/lr/precedence.go
+++ b/parser/lr/precedence.go
@@ -99,9 +99,9 @@ func (p PrecedenceLevels) Equal(rhs PrecedenceLevels) bool {
 	return true
 }
 
-// Validate checks whether a list of precedence levels is valid.
+// Verify checks whether a list of precedence levels is valid.
 // A precedence handle must not appear in multiple levels.
-func (p PrecedenceLevels) Validate() error {
+func (p PrecedenceLevels) Verify() error {
 	var err *errors.MultiError
 
 	for i := 0; i < len(p); i++ {

--- a/parser/lr/precedence_test.go
+++ b/parser/lr/precedence_test.go
@@ -139,7 +139,7 @@ func TestPrecedenceLevels_Equal(t *testing.T) {
 	}
 }
 
-func TestPrecedenceLevels_Validate(t *testing.T) {
+func TestPrecedenceLevels_Verify(t *testing.T) {
 	tests := []struct {
 		name          string
 		p             PrecedenceLevels
@@ -172,7 +172,7 @@ func TestPrecedenceLevels_Validate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.p.Validate()
+			err := tc.p.Verify()
 
 			if tc.expectedError == "" {
 				assert.NoError(t, err)


### PR DESCRIPTION
## Description

  - [x] Rename the `Validate` method to `Verify` on `PrecedenceLevels` for consistency.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
