### PR TITLE
Add automata transition type

### DIFF
--- a/automata/automata.go
+++ b/automata/automata.go
@@ -71,6 +71,14 @@ func toString(s string) String {
 	return res
 }
 
+// Transition represents a transition in a finite automaton.
+// It can be either a DFA transition with a single next state or an NFA transition with multiple next states.
+type Transition[T State | []State] struct {
+	State
+	Symbol
+	Next T
+}
+
 // stateManager is used for keeping track of states when combining multiple automata.
 type stateManager struct {
 	last   State

--- a/automata/dfa_test.go
+++ b/automata/dfa_test.go
@@ -3,6 +3,7 @@ package automata
 import (
 	"testing"
 
+	"github.com/moorara/algo/generic"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -387,6 +388,54 @@ func TestDFA_Symbols(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expectedSymbols, tc.d.Symbols())
+		})
+	}
+}
+
+func TestDFA_Transitions(t *testing.T) {
+	dfas := getTestDFAs()
+
+	tests := []struct {
+		name                string
+		d                   *DFA
+		expectedTransitions []*Transition[State]
+	}{
+		{
+			name: "First",
+			d:    dfas[0],
+			expectedTransitions: []*Transition[State]{
+				{0, 'a', 1},
+				{0, 'b', 0},
+				{1, 'a', 1},
+				{1, 'b', 2},
+				{2, 'a', 1},
+				{2, 'b', 3},
+				{3, 'a', 1},
+				{3, 'b', 0},
+			},
+		},
+		{
+			name: "Second",
+			d:    dfas[1],
+			expectedTransitions: []*Transition[State]{
+				{0, 'a', 1},
+				{0, 'b', 2},
+				{1, 'a', 1},
+				{1, 'b', 3},
+				{2, 'a', 1},
+				{2, 'b', 2},
+				{3, 'a', 1},
+				{3, 'b', 4},
+				{4, 'a', 1},
+				{4, 'b', 2},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			transitions := generic.Collect1(tc.d.Transitions())
+			assert.Equal(t, tc.expectedTransitions, transitions)
 		})
 	}
 }

--- a/automata/nfa_test.go
+++ b/automata/nfa_test.go
@@ -3,6 +3,7 @@ package automata
 import (
 	"testing"
 
+	"github.com/moorara/algo/generic"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -385,6 +386,51 @@ func TestNFA_Symbols(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expectedSymbols, tc.n.Symbols())
+		})
+	}
+}
+
+func TestNFA_Transitions(t *testing.T) {
+	nfas := getTestNFAs()
+
+	tests := []struct {
+		name                string
+		n                   *NFA
+		expectedTransitions []*Transition[[]State]
+	}{
+		{
+			name: "First",
+			n:    nfas[0],
+			expectedTransitions: []*Transition[[]State]{
+				{0, E, []State{1, 3}},
+				{1, 'a', []State{2}},
+				{2, 'a', []State{2}},
+				{3, 'b', []State{4}},
+				{4, 'b', []State{4}},
+			},
+		},
+		{
+			name: "Second",
+			n:    nfas[1],
+			expectedTransitions: []*Transition[[]State]{
+				{0, E, []State{1, 7}},
+				{1, E, []State{2, 4}},
+				{2, 'a', []State{3}},
+				{3, E, []State{6}},
+				{4, 'b', []State{5}},
+				{5, E, []State{6}},
+				{6, E, []State{1, 7}},
+				{7, 'a', []State{8}},
+				{8, 'b', []State{9}},
+				{9, 'b', []State{10}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			transitions := generic.Collect1(tc.n.Transitions())
+			assert.Equal(t, tc.expectedTransitions, transitions)
 		})
 	}
 }

--- a/automata/partition.go
+++ b/automata/partition.go
@@ -80,7 +80,7 @@ func (p *partition) BuildGroupTrans(dfa *DFA, G group) symboltable.SymbolTable[S
 		Gstrans := symboltable.NewRedBlack(CmpSymbol, EqState)
 
 		// Create a map of symbols to the current partition's group representatives (instead of next states)
-		if strans, ok := dfa.Trans.Get(s); ok {
+		if strans, ok := dfa.trans.Get(s); ok {
 			for a, next := range strans.All() {
 				if rep := p.Rep(next); rep != -1 {
 					Gstrans.Put(a, rep)


### PR DESCRIPTION
## Description

  - [x] Add the `Transition` type to the `automata` package.
  - [x] Add the `Transitions` method, which returns an iterator, to `DFA` and `NFA`.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
