### PR TITLE
dot: use Go escape sequences

### DIFF
--- a/dot/edge.go
+++ b/dot/edge.go
@@ -2,8 +2,7 @@ package dot
 
 import (
 	"bytes"
-	"fmt"
-	"strings"
+	"strconv"
 )
 
 // Edge represents an edge.
@@ -40,8 +39,7 @@ func (e *Edge) DOT() string {
 	var b bytes.Buffer
 
 	label := e.Label
-	label = strings.ReplaceAll(label, `"`, `\"`)
-	label = fmt.Sprintf(`"%s"`, label)
+	label = strconv.Quote(label)
 
 	b.WriteString(e.From + " " + string(e.EdgeType) + " " + e.To + " [")
 	first = addListAttr(&b, first, "dirType", string(e.EdgeDir))

--- a/dot/node.go
+++ b/dot/node.go
@@ -2,8 +2,7 @@ package dot
 
 import (
 	"bytes"
-	"fmt"
-	"strings"
+	"strconv"
 )
 
 // Node represents a graph node.
@@ -38,8 +37,7 @@ func (n *Node) DOT() string {
 	var b bytes.Buffer
 
 	label := n.Label
-	label = strings.ReplaceAll(label, `"`, `\"`)
-	label = fmt.Sprintf(`"%s"`, label)
+	label = strconv.Quote(label)
 
 	b.WriteString(n.Name + " [")
 	first = addListAttr(&b, first, "group", n.Group)


### PR DESCRIPTION
## Description

  - [x] Use Go *escape sequences* for quoting node and edge labels in `dot` package.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
