### PR TITLE
automata: format range strings properly

### DIFF
--- a/automata/automata.go
+++ b/automata/automata.go
@@ -19,6 +19,10 @@ var (
 	CmpSymbol  = generic.NewCompareFunc[Symbol]()
 	HashSymbol = hash.HashFuncForInt32[Symbol](nil)
 
+	eqClassID   = generic.NewEqualFunc[classID]()
+	cmpClassID  = generic.NewCompareFunc[classID]()
+	hashClassID = hash.HashFuncForInt[classID](nil)
+
 	EqStates = func(a, b States) bool {
 		if a == nil && b == nil {
 			return true
@@ -71,7 +75,8 @@ func NewStates(s ...State) States {
 type Symbol rune
 
 // E is the empty string ε and is never a member of an input alphabet Σ.
-const E Symbol = 0
+// It is intentionally chosen outside the Unicode range to avoid conflicts with valid symbols.
+const E Symbol = -1
 
 // Symbols represents a set of symbols in an automaton.
 type Symbols set.Set[Symbol]

--- a/automata/common.go
+++ b/automata/common.go
@@ -7,17 +7,37 @@ import (
 	"strings"
 
 	"github.com/moorara/algo/generic"
-	"github.com/moorara/algo/hash"
 	"github.com/moorara/algo/range/disc"
 	"github.com/moorara/algo/set"
 	"github.com/moorara/algo/symboltable"
 )
 
-var (
-	eqClassID   = generic.NewEqualFunc[classID]()
-	cmpClassID  = generic.NewCompareFunc[classID]()
-	hashClassID = hash.HashFuncForInt[classID](nil)
-)
+func formatRange(r disc.Range[Symbol]) string {
+	return fmt.Sprintf("[%s..%s]", formatRangeBound(r.Lo), formatRangeBound(r.Hi))
+}
+
+func formatRangeBound(a Symbol) string {
+	switch a {
+	case E:
+		return "ε"
+	case 0:
+		return "NUL"
+	case '\t':
+		return "\\t"
+	case '\n':
+		return "\\n"
+	case '\v':
+		return "\\v"
+	case '\f':
+		return "\\f"
+	case '\r':
+		return "\\r"
+	case ' ':
+		return "SP"
+	default:
+		return fmt.Sprintf("%c", a)
+	}
+}
 
 // rangeSet represents a set of symbol ranges.
 type rangeSet set.Set[disc.Range[Symbol]]
@@ -31,7 +51,7 @@ func newRangeSet(rs ...disc.Range[Symbol]) rangeSet {
 		func(all []disc.Range[Symbol]) string {
 			vals := make([]string, len(all))
 			for i, r := range all {
-				vals[i] = fmtRange(r)
+				vals[i] = formatRange(r)
 			}
 
 			return strings.Join(vals, ", ")
@@ -50,7 +70,7 @@ func newRangeList(rs ...disc.Range[Symbol]) rangeList {
 			Format: func(all iter.Seq[disc.Range[Symbol]]) string {
 				vals := make([]string, 0)
 				for r := range all {
-					vals = append(vals, fmtRange(r))
+					vals = append(vals, formatRange(r))
 				}
 				return strings.Join(vals, ", ")
 			},
@@ -70,7 +90,7 @@ func newRangeMapping(pairs []disc.RangeValue[Symbol, classID]) rangeMapping {
 
 			b.WriteString("Ranges:\n")
 			for r, cid := range all {
-				fmt.Fprintf(&b, "  %s: %d\n", fmtRange(r), cid)
+				fmt.Fprintf(&b, "  %s: %d\n", formatRange(r), cid)
 			}
 
 			return b.String()
@@ -134,25 +154,6 @@ func (m *stateManager) GetOrCreateState(id int, s State) State {
 	m.last++
 	m.states[id][s] = m.last
 	return m.last
-}
-
-// fmtRange formats a symbol range as a string.
-func fmtRange(r disc.Range[Symbol]) string {
-	var lo, hi Symbol
-
-	if r.Lo == E {
-		lo = 'ε'
-	} else {
-		lo = r.Lo
-	}
-
-	if r.Hi == E {
-		hi = 'ε'
-	} else {
-		hi = r.Hi
-	}
-
-	return fmt.Sprintf("[%c..%c]", lo, hi)
 }
 
 // generateStatePermutations generates all permutations of a sequence of states using recursion and backtracking.

--- a/automata/common_test.go
+++ b/automata/common_test.go
@@ -9,6 +9,71 @@ import (
 	"github.com/moorara/algo/range/disc"
 )
 
+func TestFormatRange(t *testing.T) {
+	tests := []struct {
+		name           string
+		r              disc.Range[Symbol]
+		expectedString string
+	}{
+		{
+			name:           "Empty",
+			r:              disc.Range[Symbol]{Lo: E, Hi: E},
+			expectedString: "[ε..ε]",
+		},
+		{
+			name:           "Zero",
+			r:              disc.Range[Symbol]{Lo: 0, Hi: 0},
+			expectedString: "[NUL..NUL]",
+		},
+		{
+			name:           "HorizontalTab",
+			r:              disc.Range[Symbol]{Lo: '\t', Hi: '\t'},
+			expectedString: "[\\t..\\t]",
+		},
+		{
+			name:           "Newline",
+			r:              disc.Range[Symbol]{Lo: '\n', Hi: '\n'},
+			expectedString: "[\\n..\\n]",
+		},
+		{
+			name:           "VerticalTab",
+			r:              disc.Range[Symbol]{Lo: '\v', Hi: '\v'},
+			expectedString: "[\\v..\\v]",
+		},
+		{
+			name:           "FormFeed",
+			r:              disc.Range[Symbol]{Lo: '\f', Hi: '\f'},
+			expectedString: "[\\f..\\f]",
+		},
+		{
+			name:           "CarriageReturn",
+			r:              disc.Range[Symbol]{Lo: '\r', Hi: '\r'},
+			expectedString: "[\\r..\\r]",
+		},
+		{
+			name:           "Space",
+			r:              disc.Range[Symbol]{Lo: ' ', Hi: ' '},
+			expectedString: "[SP..SP]",
+		},
+		{
+			name:           "Digit",
+			r:              disc.Range[Symbol]{Lo: '0', Hi: '9'},
+			expectedString: "[0..9]",
+		},
+		{
+			name:           "Letter",
+			r:              disc.Range[Symbol]{Lo: 'A', Hi: 'Z'},
+			expectedString: "[A..Z]",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedString, formatRange(tc.r))
+		})
+	}
+}
+
 func TestNewRangeSet(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -145,31 +210,6 @@ func TestStateManager(t *testing.T) {
 			// Test retrieving the same state again
 			state = sm.GetOrCreateState(tc.id, tc.s)
 			assert.Equal(t, tc.expectedState, state)
-		})
-	}
-}
-
-func TestFmtRange(t *testing.T) {
-	tests := []struct {
-		name           string
-		r              disc.Range[Symbol]
-		expectedString string
-	}{
-		{
-			name:           "EmptyRange",
-			r:              disc.Range[Symbol]{Lo: E, Hi: E},
-			expectedString: "[ε..ε]",
-		},
-		{
-			name:           "DigitRange",
-			r:              disc.Range[Symbol]{Lo: '0', Hi: '9'},
-			expectedString: "[0..9]",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedString, fmtRange(tc.r))
 		})
 	}
 }

--- a/grammar/symbol.go
+++ b/grammar/symbol.go
@@ -10,8 +10,9 @@ import (
 )
 
 // Endmarker is a special symbol that is used to indicate the end of a string.
-// This special symbol assumed not to be a symbol of any grammar and
-// it is taken from a Private Use Area (PUA) in Unicode.
+// The endmarker special symbol is assumed not to be a symbol of any grammar.
+// It is taken from the Unicode Private Use Area (BMP PUA) and
+// must be a valid string since the underlying type of Terminal is string.
 //
 // The endmarker is not a formal part of the grammar itself but is introduced during parsing
 // to simplify the handling of end-of-input scenarios, especially in parsing algorithms like LL(1) or LR(1).


### PR DESCRIPTION
## Description

  - [x] Format automata Symbol ranges

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
