### PR TITLE
Pin Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moorara/algo
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Description

This is a minimum version set for Go in `go.mod`, so the applications importing this library can work frictionlessly.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
