### PR TITLE
Add Size method to Productions type

### DIFF
--- a/grammar/cfg.go
+++ b/grammar/cfg.go
@@ -196,7 +196,7 @@ func (g *CFG) Equal(rhs *CFG) bool {
 
 // Symbols returns the set of all symbols in the grammar, including both terminal and non-terminal symbols.
 func (g *CFG) Symbols() set.Set[Symbol] {
-	symbols := set.New[Symbol](EqSymbol)
+	symbols := set.New(EqSymbol)
 
 	for t := range g.Terminals.All() {
 		symbols.Add(t)
@@ -1126,7 +1126,7 @@ func (g *CFG) OrderTerminals() String[Terminal] {
 	}
 
 	// Sort terminals alphabetically based on the string representation of them.
-	sort.Quick[Terminal](terms, CmpTerminal)
+	sort.Quick(terms, CmpTerminal)
 
 	return terms
 }
@@ -1175,7 +1175,7 @@ func (g *CFG) OrderNonTerminals() (String[NonTerminal], String[NonTerminal], Str
 	}
 
 	// Sort unvisited non-terminals alphabetically based on the string representation of them.
-	sort.Quick[NonTerminal](unvisited, CmpNonTerminal)
+	sort.Quick(unvisited, CmpNonTerminal)
 
 	allNonTerms := make(String[NonTerminal], 0)
 	allNonTerms = append(allNonTerms, visited...)

--- a/grammar/production.go
+++ b/grammar/production.go
@@ -130,6 +130,16 @@ func (p *Productions) Clone() *Productions {
 	return newP
 }
 
+// Size returns the number of production rules.
+func (p *Productions) Size() int {
+	size := 0
+	for _, prods := range p.table.All() {
+		size += prods.Size()
+	}
+
+	return size
+}
+
 // Add adds a new production rule.
 func (p *Productions) Add(ps ...*Production) {
 	for _, q := range ps {
@@ -175,9 +185,9 @@ func (p *Productions) Get(head NonTerminal) set.Set[*Production] {
 // All returns an iterator sequence containing all production rules.
 func (p *Productions) All() iter.Seq[*Production] {
 	return func(yield func(*Production) bool) {
-		for _, list := range p.table.All() {
-			for q := range list.All() {
-				if !yield(q) {
+		for _, prods := range p.table.All() {
+			for prod := range prods.All() {
+				if !yield(prod) {
 					return
 				}
 			}
@@ -238,7 +248,7 @@ func OrderProductionSet(set set.Set[*Production]) []*Production {
 // orderProductionSlice orders a slice of production rules in a deterministic way.
 func orderProductionSlice(prods []*Production) {
 	// Sort the productions using a custom comparison function.
-	sort.Quick[*Production](prods, cmpProduction)
+	sort.Quick(prods, cmpProduction)
 }
 
 // cmpProduction is a CompareFunc for Production type.

--- a/grammar/production_test.go
+++ b/grammar/production_test.go
@@ -253,6 +253,38 @@ func TestProductions_Clone(t *testing.T) {
 	}
 }
 
+func TestProductions_Size(t *testing.T) {
+	p := getTestProductions()
+
+	tests := []struct {
+		name         string
+		p            *Productions
+		expectedSize int
+	}{
+		{
+			name:         "1st",
+			p:            p[1],
+			expectedSize: 3,
+		},
+		{
+			name:         "2nd",
+			p:            p[2],
+			expectedSize: 9,
+		},
+		{
+			name:         "3rd",
+			p:            p[3],
+			expectedSize: 8,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedSize, tc.p.Size())
+		})
+	}
+}
+
 func TestProductions_Add(t *testing.T) {
 	p := getTestProductions()
 

--- a/parser/lr/lr.go
+++ b/parser/lr/lr.go
@@ -126,7 +126,7 @@ func (p *Parser) nextToken() (lexer.Token, error) {
 // An error is returned if the input fails to conform to the grammar rules, indicating a syntax issue,
 // or if any of the provided functions return an error, indicating a semantic issue.
 func (p *Parser) Parse(tokenF parser.TokenFunc, prodF parser.ProductionFunc) error {
-	stack := list.NewStack[State](1024, EqState)
+	stack := list.NewStack(1024, EqState)
 	stack.Push(State(0)) // BuildStateMap ensures state 0 always includes the initial item "S′ → •S"
 
 	// Read the first input token.
@@ -211,7 +211,7 @@ func (p *Parser) Parse(tokenF parser.TokenFunc, prodF parser.ProductionFunc) err
 // An error is returned if the input fails to conform to the grammar rules, indicating a syntax issue.
 func (p *Parser) ParseAndBuildAST() (parser.Node, error) {
 	// Stack for constructing the abstract syntax tree.
-	nodes := list.NewStack[parser.Node](1024, parser.EqNode)
+	nodes := list.NewStack(1024, parser.EqNode)
 
 	err := p.Parse(
 		func(token *lexer.Token) error {


### PR DESCRIPTION
## Description

  - [x] Add `Size` method to `grammar.Productions`
  - [x] Misc refactoring

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
